### PR TITLE
Add Portal 2 TU1 offsets and L4D1 GOTY support, change Source Engine IsGameSupported method

### DIFF
--- a/src/xenia/hid/winkey/hookables/Crackdown2.cc
+++ b/src/xenia/hid/winkey/hookables/Crackdown2.cc
@@ -118,12 +118,12 @@ bool Crackdown2Game::DoHooks(uint32_t user_index, RawInputState& input_state,
   // X-axis = 0 to 360
   if (!cvars::invert_x)
   {
-    degree_x -= (input_state.mouse.x_delta / 50.f) * (float)cvars::sensitivity;
+    degree_x += (input_state.mouse.x_delta / 50.f) * (float)cvars::sensitivity;
     *radian_x = DegreetoRadians(degree_x);
   }
   else
   {
-    degree_x += (input_state.mouse.x_delta / 50.f) * (float)cvars::sensitivity;
+    degree_x -= (input_state.mouse.x_delta / 50.f) * (float)cvars::sensitivity;
     *radian_x = DegreetoRadians(degree_x);
   }
 

--- a/src/xenia/hid/winkey/hookables/Crackdown2.cc
+++ b/src/xenia/hid/winkey/hookables/Crackdown2.cc
@@ -33,14 +33,15 @@ namespace xe {
 namespace hid {
 namespace winkey {
 struct GameBuildAddrs {
+  std::string title_version;
   uint32_t base_address;
   uint32_t x_offset;
   uint32_t y_offset;
 };
 
 std::map<Crackdown2Game::GameBuild, GameBuildAddrs> supported_builds{
-    {Crackdown2Game::GameBuild::Crackdown2_TU0, {0x836C6520, 0x7EC, 0x7E8}},
-    {Crackdown2Game::GameBuild::Crackdown2_TU5, {0x83800F88, 0x7EC, 0x7E8}}};
+    {Crackdown2Game::GameBuild::Crackdown2_TU0, {"1.0", 0x836C6520, 0x7EC, 0x7E8}},
+    {Crackdown2Game::GameBuild::Crackdown2_TU5, {"1.0.5", 0x83800F88, 0x7EC, 0x7E8}}};
 
 Crackdown2Game::~Crackdown2Game() = default;
 
@@ -53,15 +54,7 @@ bool Crackdown2Game::IsGameSupported() {
       kernel_state()->emulator()->title_version();
 
   for (auto& build : supported_builds) {
-    // TU 0
-    if (build.first == GameBuild::Crackdown2_TU0 && current_version == "1.0") {
-      game_build_ = build.first;
-      return true;
-    }
-
-    // TU 5
-    if (build.first == GameBuild::Crackdown2_TU5 &&
-        current_version == "1.0.5") {
+    if (current_version == build.second.title_version) {
       game_build_ = build.first;
       return true;
     }

--- a/src/xenia/hid/winkey/hookables/Crackdown2.cc
+++ b/src/xenia/hid/winkey/hookables/Crackdown2.cc
@@ -33,15 +33,15 @@ namespace xe {
 namespace hid {
 namespace winkey {
 struct GameBuildAddrs {
-  std::string title_version;
   uint32_t base_address;
+  std::string title_version;
   uint32_t x_offset;
   uint32_t y_offset;
 };
 
 std::map<Crackdown2Game::GameBuild, GameBuildAddrs> supported_builds{
-    {Crackdown2Game::GameBuild::Crackdown2_TU0, {"1.0", 0x836C6520, 0x7EC, 0x7E8}},
-    {Crackdown2Game::GameBuild::Crackdown2_TU5, {"1.0.5", 0x83800F88, 0x7EC, 0x7E8}}};
+    {Crackdown2Game::GameBuild::Crackdown2_TU0, {0x836C6520, "1.0", 0x7EC, 0x7E8}},
+    {Crackdown2Game::GameBuild::Crackdown2_TU5, {0x83800F88, "1.0.5", 0x7EC, 0x7E8}}};
 
 Crackdown2Game::~Crackdown2Game() = default;
 
@@ -116,7 +116,7 @@ bool Crackdown2Game::DoHooks(uint32_t user_index, RawInputState& input_state,
   float degree_y = RadianstoDegree(*radian_y);
 
   // X-axis = 0 to 360
-  if (cvars::invert_x)
+  if (!cvars::invert_x)
   {
     degree_x -= (input_state.mouse.x_delta / 50.f) * (float)cvars::sensitivity;
     *radian_x = DegreetoRadians(degree_x);
@@ -128,10 +128,10 @@ bool Crackdown2Game::DoHooks(uint32_t user_index, RawInputState& input_state,
   }
 
   // Y-axis = -90 to 90
-  if (cvars::invert_y) {
-    degree_y -= (input_state.mouse.y_delta / 50.f) * (float)cvars::sensitivity;
-  } else {
+  if (!cvars::invert_y) {
     degree_y += (input_state.mouse.y_delta / 50.f) * (float)cvars::sensitivity;
+  } else {
+    degree_y -= (input_state.mouse.y_delta / 50.f) * (float)cvars::sensitivity;
   }
 
   *radian_y = DegreetoRadians(degree_y);

--- a/src/xenia/hid/winkey/hookables/Crackdown2.cc
+++ b/src/xenia/hid/winkey/hookables/Crackdown2.cc
@@ -123,14 +123,14 @@ bool Crackdown2Game::DoHooks(uint32_t user_index, RawInputState& input_state,
   float degree_y = RadianstoDegree(*radian_y);
 
   // X-axis = 0 to 360
-  if (!cvars::invert_x)
+  if (cvars::invert_x)
   {
-    degree_x += (input_state.mouse.x_delta / 50.f) * (float)cvars::sensitivity;
+    degree_x -= (input_state.mouse.x_delta / 50.f) * (float)cvars::sensitivity;
     *radian_x = DegreetoRadians(degree_x);
   }
   else
   {
-    degree_x -= (input_state.mouse.x_delta / 50.f) * (float)cvars::sensitivity;
+    degree_x += (input_state.mouse.x_delta / 50.f) * (float)cvars::sensitivity;
     *radian_x = DegreetoRadians(degree_x);
   }
 

--- a/src/xenia/hid/winkey/hookables/SourceEngine.cc
+++ b/src/xenia/hid/winkey/hookables/SourceEngine.cc
@@ -69,23 +69,23 @@ std::map<SourceEngine::GameBuild, GameBuildAddrs> supported_builds{
     }, 
     {
         SourceEngine::GameBuild::L4D1, 
-        {kTitleIdL4D1, "", 0x86536888, 0x4B44}
+        {kTitleIdL4D1, "1.0", 0x86536888, 0x4B44}
     },
     {
         SourceEngine::GameBuild::L4D2, 
-        {kTitleIdL4D2, "", 0x86CC4E60, 0x4A94}
+        {kTitleIdL4D2, "3.0", 0x86CC4E60, 0x4A94}
     },
     {
         SourceEngine::GameBuild::OrangeBox, 
-        {kTitleIdOrangeBox, "", NULL, 0x863F53A8}
+        {kTitleIdOrangeBox, "4.0", NULL, 0x863F53A8}
     },
     {
         SourceEngine::GameBuild::PortalSA,
-        {kTitleIdPortalSA, "", NULL, 0x863F56B0}
+        {kTitleIdPortalSA, "3.0.1", NULL, 0x863F56B0}
     },
     {
         SourceEngine::GameBuild::Portal2,
-        {kTitleIdPortal2, "4.0.0", 0x82C50180, 0x4A98}
+        {kTitleIdPortal2, "4.0", 0x82C50180, 0x4A98}
     },
     {
         SourceEngine::GameBuild::Portal2_TU1,

--- a/src/xenia/hid/winkey/hookables/SourceEngine.cc
+++ b/src/xenia/hid/winkey/hookables/SourceEngine.cc
@@ -72,6 +72,10 @@ std::map<SourceEngine::GameBuild, GameBuildAddrs> supported_builds{
         {kTitleIdL4D1, "1.0", 0x86536888, 0x4B44}
     },
     {
+        SourceEngine::GameBuild::L4D1_GOTY, 
+        {kTitleIdL4D1, "6.0", 0x86537FA0, 0x4B44}
+    },
+    {
         SourceEngine::GameBuild::L4D2, 
         {kTitleIdL4D2, "3.0", 0x86CC4E60, 0x4A94}
     },
@@ -89,7 +93,7 @@ std::map<SourceEngine::GameBuild, GameBuildAddrs> supported_builds{
     },
     {
         SourceEngine::GameBuild::Portal2_TU1,
-        {kTitleIdPortal2, "4.0.1", 0x82C50180, 0x4A98}
+        {kTitleIdPortal2, "4.0.1", 0x82C50220, 0x4A98}
     }
 };
 
@@ -135,12 +139,6 @@ bool SourceEngine::DoHooks(uint32_t user_index, RawInputState& input_state,
 
   if (!current_thread) {
     return false;
-  }
-
-  uint32_t game_control_disabled = 0;
-  game_control_disabled = *kernel_memory()->TranslateVirtual<xe::be<uint32_t>*>(0x88711CE4);
-  if (game_control_disabled) {
-    return true;
   }
 
   uint32_t player_ptr;

--- a/src/xenia/hid/winkey/hookables/SourceEngine.cc
+++ b/src/xenia/hid/winkey/hookables/SourceEngine.cc
@@ -137,6 +137,12 @@ bool SourceEngine::DoHooks(uint32_t user_index, RawInputState& input_state,
     return false;
   }
 
+  uint32_t game_control_disabled = 0;
+  game_control_disabled = *kernel_memory()->TranslateVirtual<xe::be<uint32_t>*>(0x88711CE4);
+  if (game_control_disabled) {
+    return true;
+  }
+
   uint32_t player_ptr;
   if (supported_builds[game_build_].execute_addr)
   {
@@ -186,22 +192,22 @@ bool SourceEngine::DoHooks(uint32_t user_index, RawInputState& input_state,
     }
   }
 
-  if (cvars::invert_x)
-  {
-    camX +=
-        (((float)input_state.mouse.x_delta) / 7.5f) * (float)cvars::sensitivity;
-  }
-  else
+  if (!cvars::invert_x)
   {
     camX -=
         (((float)input_state.mouse.x_delta) / 7.5f) * (float)cvars::sensitivity;
   }
+  else
+  {
+    camX +=
+        (((float)input_state.mouse.x_delta) / 7.5f) * (float)cvars::sensitivity;
+  }
 
-  if (cvars::invert_y) {
-    camY -=
+  if (!cvars::invert_y) {
+    camY +=
         (((float)input_state.mouse.y_delta) / 7.5f) * (float)cvars::sensitivity;
   } else {
-    camY +=
+    camY -=
         (((float)input_state.mouse.y_delta) / 7.5f) * (float)cvars::sensitivity;
   }
 

--- a/src/xenia/hid/winkey/hookables/SourceEngine.cc
+++ b/src/xenia/hid/winkey/hookables/SourceEngine.cc
@@ -29,8 +29,6 @@ DECLARE_int32(walk_orthogonal);
 DECLARE_int32(walk_diagonal);
 
 const uint32_t kTitleIdCSGO = 0x5841125A;
-const std::string kBetaVersion = "1.0.1.16";
-
 const uint32_t kTitleIdL4D1 = 0x45410830;
 const uint32_t kTitleIdL4D2 = 0x454108D4;
 const uint32_t kTitleIdOrangeBox = 0x4541080F;
@@ -48,12 +46,13 @@ bool __inline IsKeyToggled(uint8_t key) {
 SourceEngine::SourceEngine() {
   original_sensitivity = cvars::sensitivity;
   engine_360 = NULL;
-  isBeta = false;
 };
 
 SourceEngine::~SourceEngine() = default;
 
 struct GameBuildAddrs {
+  uint32_t title_id;
+  std::string title_version;
   uint32_t execute_addr;
   uint32_t angle_offset;
 };
@@ -62,65 +61,53 @@ struct GameBuildAddrs {
 std::map<SourceEngine::GameBuild, GameBuildAddrs> supported_builds{
     {
         SourceEngine::GameBuild::CSGO, 
-        {0x86955490, 0x4AE8}
+        {kTitleIdCSGO, "5.0", 0x86955490, 0x4AE8}
+    },
+    {
+        SourceEngine::GameBuild::CSGO_Beta, 
+        {kTitleIdCSGO, "1.0.1.16", 0x8697DB30, 0x4AC8}
     }, 
     {
         SourceEngine::GameBuild::L4D1, 
-        {0x86536888, 0x4B44}
+        {kTitleIdL4D1, "", 0x86536888, 0x4B44}
     },
     {
         SourceEngine::GameBuild::L4D2, 
-        {0x86CC4E60, 0x4A94}
+        {kTitleIdL4D2, "", 0x86CC4E60, 0x4A94}
     },
     {
         SourceEngine::GameBuild::OrangeBox, 
-        {NULL, 0x863F53A8}
+        {kTitleIdOrangeBox, "", NULL, 0x863F53A8}
     },
     {
         SourceEngine::GameBuild::PortalSA,
-        {NULL, 0x863F56B0}
+        {kTitleIdPortalSA, "", NULL, 0x863F56B0}
     },
     {
         SourceEngine::GameBuild::Portal2,
-        {0x82C50180, 0x4A98}
+        {kTitleIdPortal2, "4.0.0", 0x82C50180, 0x4A98}
+    },
+    {
+        SourceEngine::GameBuild::Portal2_TU1,
+        {kTitleIdPortal2, "4.0.1", 0x82C50180, 0x4A98}
     }
 };
 
 bool SourceEngine::IsGameSupported() {
   auto title_id = kernel_state()->title_id();
+  if (title_id != kTitleIdCSGO && title_id != kTitleIdL4D1 && title_id != kTitleIdL4D2 && title_id != kTitleIdOrangeBox && title_id != kTitleIdPortalSA && title_id != kTitleIdPortal2)
+      return false;
 
-  switch (title_id) 
+  const std::string current_version =
+      kernel_state()->emulator()->title_version();
+
+  for (auto& build : supported_builds)
   {
-  case kTitleIdCSGO:
-      {
-           game_build_ = SourceEngine::GameBuild::CSGO; 
-           return true;
-      }
-  case kTitleIdL4D1:
-      {
-           game_build_ = SourceEngine::GameBuild::L4D1;
-           return true;
-      }
-  case kTitleIdL4D2:
-      {
-           game_build_ = SourceEngine::GameBuild::L4D2;
-           return true;
-      }
-  case kTitleIdOrangeBox:
-      {
-           game_build_ = SourceEngine::GameBuild::OrangeBox;
-           return true;
-      }
-  case kTitleIdPortalSA:
-      {
-           game_build_ = SourceEngine::GameBuild::PortalSA;
-           return true;
-      }
-  case kTitleIdPortal2:
-      {
-           game_build_ = SourceEngine::GameBuild::Portal2;
-           return true;
-      }
+    if (title_id == build.second.title_id && current_version == build.second.title_version)
+    {
+      game_build_ = build.first;
+      return true;
+    }
   }
 
   return false;
@@ -150,24 +137,14 @@ bool SourceEngine::DoHooks(uint32_t user_index, RawInputState& input_state,
     return false;
   }
 
-  if (kernel_state()->emulator()->title_version() == kBetaVersion) {
-    isBeta = true;
-  }
-
   uint32_t player_ptr;
   if (supported_builds[game_build_].execute_addr)
   {
       current_thread->thread_state()->context()->r[3] = -1;
 
-      // CS:GO Beta
-      if (isBeta) {
-        kernel_state()->processor()->Execute(current_thread->thread_state(),
-                                             0x8697DB30);
-      } else {
-        kernel_state()->processor()->Execute(
+      kernel_state()->processor()->Execute(
             current_thread->thread_state(),
             supported_builds[game_build_].execute_addr);
-      }
 
       // Get player pointer
       player_ptr =
@@ -181,13 +158,7 @@ bool SourceEngine::DoHooks(uint32_t user_index, RawInputState& input_state,
 
   xe::be<uint32_t>* angle_offset;
 
-  // CS:GO Beta
-  if (isBeta) 
-  {
-    angle_offset = kernel_memory()->TranslateVirtual<xe::be<uint32_t>*>(
-        player_ptr + 0x4AC8);
-  } 
-  else if (!supported_builds[game_build_].execute_addr)
+  if (!supported_builds[game_build_].execute_addr)
   {
     angle_offset = kernel_memory()->TranslateVirtual<xe::be<uint32_t>*>(supported_builds[game_build_].angle_offset); 
   }

--- a/src/xenia/hid/winkey/hookables/SourceEngine.cc
+++ b/src/xenia/hid/winkey/hookables/SourceEngine.cc
@@ -158,14 +158,14 @@ bool SourceEngine::DoHooks(uint32_t user_index, RawInputState& input_state,
 
   xe::be<uint32_t>* angle_offset;
 
-  if (!supported_builds[game_build_].execute_addr)
-  {
-    angle_offset = kernel_memory()->TranslateVirtual<xe::be<uint32_t>*>(supported_builds[game_build_].angle_offset); 
-  }
-  else 
+  if (supported_builds[game_build_].execute_addr)
   {
     angle_offset = kernel_memory()->TranslateVirtual<xe::be<uint32_t>*>(
         player_ptr + supported_builds[game_build_].angle_offset);
+  }
+  else 
+  {
+    angle_offset = kernel_memory()->TranslateVirtual<xe::be<uint32_t>*>(supported_builds[game_build_].angle_offset); 
   }
 
   QAngle* ang = reinterpret_cast<QAngle*>(angle_offset);
@@ -186,23 +186,23 @@ bool SourceEngine::DoHooks(uint32_t user_index, RawInputState& input_state,
     }
   }
 
-  if (!cvars::invert_x)
-  {
-    camX -=
-        (((float)input_state.mouse.x_delta) / 7.5f) * (float)cvars::sensitivity;
-  }
-  else
+  if (cvars::invert_x)
   {
     camX +=
         (((float)input_state.mouse.x_delta) / 7.5f) * (float)cvars::sensitivity;
   }
+  else
+  {
+    camX -=
+        (((float)input_state.mouse.x_delta) / 7.5f) * (float)cvars::sensitivity;
+  }
 
-  if (!cvars::invert_y) {
-    camY += (((float)input_state.mouse.y_delta) / 7.5f) *
-            (float)cvars::sensitivity;
+  if (cvars::invert_y) {
+    camY -=
+        (((float)input_state.mouse.y_delta) / 7.5f) * (float)cvars::sensitivity;
   } else {
-    camY -= (((float)input_state.mouse.y_delta) / 7.5f) *
-            (float)cvars::sensitivity;
+    camY +=
+        (((float)input_state.mouse.y_delta) / 7.5f) * (float)cvars::sensitivity;
   }
 
   ang->pitchX = camX;

--- a/src/xenia/hid/winkey/hookables/SourceEngine.h
+++ b/src/xenia/hid/winkey/hookables/SourceEngine.h
@@ -23,6 +23,7 @@ class SourceEngine : public HookableGame {
     CSGO,
     CSGO_Beta,
     L4D1,
+    L4D1_GOTY,
     L4D2,
     OrangeBox,
     PortalSA,

--- a/src/xenia/hid/winkey/hookables/SourceEngine.h
+++ b/src/xenia/hid/winkey/hookables/SourceEngine.h
@@ -21,11 +21,13 @@ class SourceEngine : public HookableGame {
   enum class GameBuild {
     Unknown,
     CSGO,
+    CSGO_Beta,
     L4D1,
     L4D2,
     OrangeBox,
     PortalSA,
-    Portal2
+    Portal2,
+    Portal2_TU1
   };
 
   SourceEngine();
@@ -49,8 +51,6 @@ class SourceEngine : public HookableGame {
   bool engine_360;
 
   double original_sensitivity;
-
-  bool isBeta;
 };
 
 }  // namespace winkey

--- a/src/xenia/hid/winkey/hookables/goldeneye.cc
+++ b/src/xenia/hid/winkey/hookables/goldeneye.cc
@@ -345,23 +345,22 @@ bool GoldeneyeGame::DoHooks(uint32_t user_index, RawInputState& input_state,
     float chX = *player_crosshair_x;
     float chY = *player_crosshair_y;
 
-    if (cvars::invert_x) 
+    if (!cvars::invert_x) 
     {
-      chX -= (((float)input_state.mouse.x_delta) / dividor) *
+      chX += (((float)input_state.mouse.x_delta) / dividor) *
              (float)cvars::sensitivity;
     } 
     else 
     {
-        
-      chX += (((float)input_state.mouse.x_delta) / dividor) *
+      chX -= (((float)input_state.mouse.x_delta) / dividor) *
              (float)cvars::sensitivity;
     }
 
-    if (cvars::invert_y) {
-      chY -= (((float)input_state.mouse.y_delta) / dividor) *
+    if (!cvars::invert_y) {
+      chY += (((float)input_state.mouse.y_delta) / dividor) *
              (float)cvars::sensitivity;
     } else {
-      chY += (((float)input_state.mouse.y_delta) / dividor) *
+      chY -= (((float)input_state.mouse.y_delta) / dividor) *
              (float)cvars::sensitivity;
     }
 

--- a/src/xenia/hid/winkey/hookables/goldeneye.cc
+++ b/src/xenia/hid/winkey/hookables/goldeneye.cc
@@ -345,23 +345,24 @@ bool GoldeneyeGame::DoHooks(uint32_t user_index, RawInputState& input_state,
     float chX = *player_crosshair_x;
     float chY = *player_crosshair_y;
 
-    if (!cvars::invert_x) 
+    if (cvars::invert_x) 
     {
-        chX += (((float)input_state.mouse.x_delta) / dividor) *
-           (float)cvars::sensitivity;
+      chX -= (((float)input_state.mouse.x_delta) / dividor) *
+             (float)cvars::sensitivity;
     } 
     else 
     {
-        chX -= (((float)input_state.mouse.x_delta) / dividor) *
-            (float)cvars::sensitivity;
+        
+      chX += (((float)input_state.mouse.x_delta) / dividor) *
+             (float)cvars::sensitivity;
     }
 
-    if (!cvars::invert_y) {
-      chY += (((float)input_state.mouse.y_delta) / dividor) *
-              (float)cvars::sensitivity;
-    } else {
+    if (cvars::invert_y) {
       chY -= (((float)input_state.mouse.y_delta) / dividor) *
-              (float)cvars::sensitivity;
+             (float)cvars::sensitivity;
+    } else {
+      chY += (((float)input_state.mouse.y_delta) / dividor) *
+             (float)cvars::sensitivity;
     }
 
     // Keep the gun/crosshair in-bounds [1:-1]

--- a/src/xenia/hid/winkey/hookables/halo3.cc
+++ b/src/xenia/hid/winkey/hookables/halo3.cc
@@ -167,22 +167,22 @@ bool Halo3Game::DoHooks(uint32_t user_index, RawInputState& input_state,
       float camX = (float)*player_cam_x;
       float camY = (float)*player_cam_y;
 
-      if (!cvars::invert_x)
-      {
-        camX -= (((float)input_state.mouse.x_delta) / 1000.f) *
-              (float)cvars::sensitivity;
-      }
-      else
+      if (cvars::invert_x)
       {
         camX += (((float)input_state.mouse.x_delta) / 1000.f) *
                 (float)cvars::sensitivity;
       }
+      else
+      {
+        camX -= (((float)input_state.mouse.x_delta) / 1000.f) *
+                (float)cvars::sensitivity;
+      }
 
-      if (!cvars::invert_y) {
-        camY -= (((float)input_state.mouse.y_delta) / 1000.f) *
+      if (cvars::invert_y) {
+        camY += (((float)input_state.mouse.y_delta) / 1000.f) *
                 (float)cvars::sensitivity;
       } else {
-        camY += (((float)input_state.mouse.y_delta) / 1000.f) *
+        camY -= (((float)input_state.mouse.y_delta) / 1000.f) *
                 (float)cvars::sensitivity;
       }
 

--- a/src/xenia/hid/winkey/hookables/halo3.cc
+++ b/src/xenia/hid/winkey/hookables/halo3.cc
@@ -167,22 +167,22 @@ bool Halo3Game::DoHooks(uint32_t user_index, RawInputState& input_state,
       float camX = (float)*player_cam_x;
       float camY = (float)*player_cam_y;
 
-      if (cvars::invert_x)
-      {
-        camX += (((float)input_state.mouse.x_delta) / 1000.f) *
-                (float)cvars::sensitivity;
-      }
-      else
+      if (!cvars::invert_x)
       {
         camX -= (((float)input_state.mouse.x_delta) / 1000.f) *
                 (float)cvars::sensitivity;
       }
+      else
+      {
+        camX += (((float)input_state.mouse.x_delta) / 1000.f) *
+                (float)cvars::sensitivity;
+      }
 
-      if (cvars::invert_y) {
-        camY += (((float)input_state.mouse.y_delta) / 1000.f) *
+      if (!cvars::invert_y) {
+        camY -= (((float)input_state.mouse.y_delta) / 1000.f) *
                 (float)cvars::sensitivity;
       } else {
-        camY -= (((float)input_state.mouse.y_delta) / 1000.f) *
+        camY += (((float)input_state.mouse.y_delta) / 1000.f) *
                 (float)cvars::sensitivity;
       }
 


### PR DESCRIPTION
Needs confirmation of working current_version values for:
- [x] CS:GO
- [x] CS:GO Beta
- [x] L4D1
- [x] L4D1 GOTY
- [x] L4D2
- [x] Orange Box
- [x] Portal: Still Alive
- [x] Portal 2
- [ ] Portal 2 TU1
- [x] Crackdown 2
- [x] Crackdown 2 TU5