### PR TITLE
Remove XThread check from several games.

### DIFF
--- a/src/xenia/hid/winkey/hookables/CallOfDuty.cc
+++ b/src/xenia/hid/winkey/hookables/CallOfDuty.cc
@@ -219,18 +219,6 @@ bool CallOfDutyGame::DoHooks(uint32_t user_index, RawInputState& input_state,
     return false;
   }
 
-  XThread* current_thread = XThread::GetCurrentThread();
-
-  if (!current_thread) {
-    return false;
-  }
-  if (supported_builds[game_build_].Dvar_GetBool_address != NULL) {
-    if (!Dvar_GetBool("cl_ingame",
-                      supported_builds[game_build_].Dvar_GetBool_address)) {
-      return false;
-    }
-  }
-
   xe::be<float>* degree_x;
   xe::be<float>* degree_y;
 

--- a/src/xenia/hid/winkey/hookables/CallOfDuty.cc
+++ b/src/xenia/hid/winkey/hookables/CallOfDuty.cc
@@ -218,7 +218,9 @@ bool CallOfDutyGame::DoHooks(uint32_t user_index, RawInputState& input_state,
   if (!IsGameSupported()) {
     return false;
   }
-
+  if ((!input_state.mouse.x_delta && !input_state.mouse.y_delta &&
+       !input_state.mouse.wheel_delta))
+    return false;
   xe::be<float>* degree_x;
   xe::be<float>* degree_y;
 

--- a/src/xenia/hid/winkey/hookables/Crackdown2.cc
+++ b/src/xenia/hid/winkey/hookables/Crackdown2.cc
@@ -82,7 +82,9 @@ bool Crackdown2Game::DoHooks(uint32_t user_index, RawInputState& input_state,
   if (supported_builds.count(game_build_) == 0) {
     return false;
   }
-
+  if ((!input_state.mouse.x_delta && !input_state.mouse.y_delta &&
+       !input_state.mouse.wheel_delta))
+    return false;
   xe::be<uint32_t>* base_address =
       kernel_memory()->TranslateVirtual<xe::be<uint32_t>*>(
           supported_builds[game_build_].base_address);

--- a/src/xenia/hid/winkey/hookables/Crackdown2.cc
+++ b/src/xenia/hid/winkey/hookables/Crackdown2.cc
@@ -83,12 +83,6 @@ bool Crackdown2Game::DoHooks(uint32_t user_index, RawInputState& input_state,
     return false;
   }
 
-  XThread* current_thread = XThread::GetCurrentThread();
-
-  if (!current_thread) {
-    return false;
-  }
-
   xe::be<uint32_t>* base_address =
       kernel_memory()->TranslateVirtual<xe::be<uint32_t>*>(
           supported_builds[game_build_].base_address);

--- a/src/xenia/hid/winkey/hookables/DeadRising.cc
+++ b/src/xenia/hid/winkey/hookables/DeadRising.cc
@@ -80,12 +80,6 @@ bool DeadRisingGame::DoHooks(uint32_t user_index, RawInputState& input_state,
     return false;
   }
 
-  XThread* current_thread = XThread::GetCurrentThread();
-
-  if (!current_thread) {
-    return false;
-  }
-
   xe::be<float>* radian_x = kernel_memory()->TranslateVirtual<xe::be<float>*>(
       supported_builds[game_build_].x_address);
 

--- a/src/xenia/hid/winkey/hookables/DeadRising.cc
+++ b/src/xenia/hid/winkey/hookables/DeadRising.cc
@@ -79,7 +79,9 @@ bool DeadRisingGame::DoHooks(uint32_t user_index, RawInputState& input_state,
   if (!IsGameSupported()) {
     return false;
   }
-
+  if ((!input_state.mouse.x_delta && !input_state.mouse.y_delta &&
+       !input_state.mouse.wheel_delta))
+    return false;
   xe::be<float>* radian_x = kernel_memory()->TranslateVirtual<xe::be<float>*>(
       supported_builds[game_build_].x_address);
 

--- a/src/xenia/hid/winkey/hookables/Farcry.cc
+++ b/src/xenia/hid/winkey/hookables/Farcry.cc
@@ -72,12 +72,6 @@ bool FarCryGame::DoHooks(uint32_t user_index, RawInputState& input_state,
     return false;
   }
 
-  XThread* current_thread = XThread::GetCurrentThread();
-
-  if (!current_thread) {
-    return false;
-  }
-
   xe::be<uint32_t>* base_address =
       kernel_memory()->TranslateVirtual<xe::be<uint32_t>*>(
           supported_builds[game_build_].base_address);

--- a/src/xenia/hid/winkey/hookables/Farcry.cc
+++ b/src/xenia/hid/winkey/hookables/Farcry.cc
@@ -72,6 +72,10 @@ bool FarCryGame::DoHooks(uint32_t user_index, RawInputState& input_state,
     return false;
   }
 
+  if ((!input_state.mouse.x_delta && !input_state.mouse.y_delta &&
+       !input_state.mouse.wheel_delta))
+    return false;
+
   xe::be<uint32_t>* base_address =
       kernel_memory()->TranslateVirtual<xe::be<uint32_t>*>(
           supported_builds[game_build_].base_address);

--- a/src/xenia/hid/winkey/hookables/GearsOfWars.cc
+++ b/src/xenia/hid/winkey/hookables/GearsOfWars.cc
@@ -274,12 +274,6 @@ bool GearsOfWarsGame::DoHooks(uint32_t user_index, RawInputState& input_state,
     }
   }
 
-  XThread* current_thread = XThread::GetCurrentThread();
-
-  if (!current_thread) {
-    return false;
-  }
-
   if (bypass_conditions) {
     xe::be<uint16_t>* degree_x;
     xe::be<uint16_t>* degree_y;

--- a/src/xenia/hid/winkey/hookables/JustCause.cc
+++ b/src/xenia/hid/winkey/hookables/JustCause.cc
@@ -89,7 +89,7 @@ bool JustCauseGame::DoHooks(uint32_t user_index, RawInputState& input_state,
   }
 
   /*
-TODO: Vehicle Camera which is CMachineCamera
+MOUSEHOOK TODO: Vehicle Camera which is CMachineCamera
 and Possibly turrets which is CMountedGunCamera
 
 Some addresses used are in radians,
@@ -117,6 +117,7 @@ GTA-styled freecam.
 
   xe::be<float>* add_y =
       kernel_memory()->TranslateVirtual<xe::be<float>*>(y_address);
+  // MOUSEHOOK TODO do camx = and camy = instead of +=
 
   float camx = *add_x;
   float camy = *add_y;

--- a/src/xenia/hid/winkey/hookables/RDR.cc
+++ b/src/xenia/hid/winkey/hookables/RDR.cc
@@ -158,10 +158,6 @@ bool RedDeadRedemptionGame::DoHooks(uint32_t user_index,
                        now - last_movement_time_y_)
                        .count();
 
-  XThread* current_thread = XThread::GetCurrentThread();
-  if (!current_thread) {
-    return false;
-  }
   if (IsPaused()) return false;
 
   xe::be<uint32_t>* base_address =

--- a/src/xenia/hid/winkey/hookables/RDR.cc
+++ b/src/xenia/hid/winkey/hookables/RDR.cc
@@ -330,7 +330,10 @@ bool RedDeadRedemptionGame::DoHooks(uint32_t user_index,
         }
       }
     }
-
+    if ((!input_state.mouse.x_delta && !input_state.mouse.y_delta &&
+         !input_state.mouse.wheel_delta))
+      return false;  // This late because want the pattern scans to occur during
+                     // loading screen.
     xe::be<uint32_t> x_address =
         *base_address - supported_builds[game_build_].x_offset;
     xe::be<uint32_t> y_address =

--- a/src/xenia/hid/winkey/hookables/SaintsRow2.cc
+++ b/src/xenia/hid/winkey/hookables/SaintsRow2.cc
@@ -150,12 +150,6 @@ bool SaintsRow2Game::DoHooks(uint32_t user_index, RawInputState& input_state,
     }
   }
 
-  XThread* current_thread = XThread::GetCurrentThread();
-
-  if (!current_thread) {
-    return false;
-  }
-
   auto* sniper_status = kernel_memory()->TranslateVirtual<uint8_t*>(
       supported_builds[game_build_].sniper_status_address);
 
@@ -319,6 +313,10 @@ uint64_t SaintsRow2Game::reset_fineaim(uint32_t function_address,
                                        uint32_t player_ptr, uint32_t a2,
                                        uint32_t a3) {
   XThread* current_thread = XThread::GetCurrentThread();
+
+  if (!current_thread) {
+    return 0;
+  }
 
   if (function_address == NULL && player_ptr == NULL) {
     return 0;


### PR DESCRIPTION
This GREATLY improves mouse accuracy when the framerate is low or if the game is stuttering.