### PR TITLE
Keyboard light fixes

### DIFF
--- a/src/xenia/hid/winkey/winkey_input_driver.cc
+++ b/src/xenia/hid/winkey/winkey_input_driver.cc
@@ -650,9 +650,7 @@ X_RESULT WinKeyInputDriver::GetState(uint32_t user_index,
     }
   } else {  // So keys don't get 'stuck' if they were held previously when
             // tabbing in and out from the window
-    for (auto& state : key_states_) {
-      state = false;
-    }
+    memset(key_states_, 0, 256);
     mouse_events_ = {};
   }
 

--- a/src/xenia/hid/winkey/winkey_input_driver.cc
+++ b/src/xenia/hid/winkey/winkey_input_driver.cc
@@ -648,6 +648,12 @@ X_RESULT WinKeyInputDriver::GetState(uint32_t user_index,
         }
       }
     }
+  } else {  // So keys don't get 'stuck' if they were held previously when
+            // tabbing in and out from the window
+    for (auto& state : key_states_) {
+      state = false;
+    }
+    mouse_events_ = {};
   }
 
   out_state->packet_number = packet_number_;

--- a/src/xenia/hid/winkey/winkey_input_driver.cc
+++ b/src/xenia/hid/winkey/winkey_input_driver.cc
@@ -561,7 +561,7 @@ X_RESULT WinKeyInputDriver::GetState(uint32_t user_index,
         const auto vk_key = static_cast<ui::VirtualKey>(i);
 
         if (!binds.count(vk_key)) {
-          break;
+          continue;
         }
 
         const auto binding = binds.at(vk_key);


### PR DESCRIPTION
Address #31

1. Don't skip processing unbound keys, fixes unbound keys from disabling controls, which should fix keys getting stuck after pressing certain hotkeys thus disabling entire controls for the current session, reported cases: CTRL-SHIFT-O, AMD/NVIDIA overlays & FN+Volume keys.
2. Fix keys getting stuck if they were held while the window became inactive e.g holding mouse1 then alt-tabbing caused mouse1 to still act if it's held when returning to the window

also include bindings in actions just because