### PR TITLE
Display notification when current version of game is unsupported

### DIFF
--- a/src/xenia/hid/winkey/hookables/CallOfDuty.cc
+++ b/src/xenia/hid/winkey/hookables/CallOfDuty.cc
@@ -216,6 +216,12 @@ bool CallOfDutyGame::IsGameSupported() {
     }
   }
 
+#ifdef XENIA_MOUSEHOOK_MESSAGE
+  mousehook_message_wrapper(
+      "MOUSEHOOK: Supported Title ID, but unsupported version of Call Of Duty, "
+      "refer to the Github repo for supported titles.",
+      true);
+#endif
   return false;
 }
 

--- a/src/xenia/hid/winkey/hookables/Crackdown2.cc
+++ b/src/xenia/hid/winkey/hookables/Crackdown2.cc
@@ -61,7 +61,21 @@ bool Crackdown2Game::IsGameSupported() {
       return true;
     }
   }
-
+#ifdef XENIA_MOUSEHOOK_MESSAGE
+  mousehook_message_wrapper(
+      std::format("MOUSEHOOK: Supported Title ID, but current version '{}' is "
+                  "unsupported. Expected: [{}]",
+                  current_version,
+                  [&]() {
+                    std::string versions;
+                    for (const auto& build : supported_builds) {
+                      if (!versions.empty()) versions += ", ";
+                      versions += build.second.title_version;
+                    }
+                    return versions;
+                  }()),
+      true);
+#endif
   return false;
 }
 

--- a/src/xenia/hid/winkey/hookables/Farcry.cc
+++ b/src/xenia/hid/winkey/hookables/Farcry.cc
@@ -59,6 +59,22 @@ bool FarCryGame::IsGameSupported() {
     }
   }
 
+#ifdef XENIA_MOUSEHOOK_MESSAGE
+  mousehook_message_wrapper(
+      std::format("MOUSEHOOK: Supported Title ID, but current version '{}' is "
+                  "unsupported. Expected: [{}]",
+                  current_version,
+                  [&]() {
+                    std::string versions;
+                    for (const auto& build : supported_builds) {
+                      if (!versions.empty()) versions += ", ";
+                      versions += build.second.title_version;
+                    }
+                    return versions;
+                  }()),
+      true);
+#endif
+
   return false;
 }
 

--- a/src/xenia/hid/winkey/hookables/JustCause.cc
+++ b/src/xenia/hid/winkey/hookables/JustCause.cc
@@ -60,6 +60,22 @@ bool JustCauseGame::IsGameSupported() {
     }
   }
 
+#ifdef XENIA_MOUSEHOOK_MESSAGE
+  mousehook_message_wrapper(
+      std::format("MOUSEHOOK: Supported Title ID, but current version '{}' is "
+                  "unsupported. Expected: [{}]",
+                  current_version,
+                  [&]() {
+                    std::string versions;
+                    for (const auto& build : supported_builds) {
+                      if (!versions.empty()) versions += ", ";
+                      versions += build.second.title_version;
+                    }
+                    return versions;
+                  }()),
+      true);
+#endif
+
   return false;
 }
 

--- a/src/xenia/hid/winkey/hookables/Minecraft.cc
+++ b/src/xenia/hid/winkey/hookables/Minecraft.cc
@@ -100,6 +100,22 @@ bool MinecraftGame::IsGameSupported() {
     }
   }
 
+#ifdef XENIA_MOUSEHOOK_MESSAGE
+  mousehook_message_wrapper(
+      std::format("MOUSEHOOK: Supported Title ID, but current version '{}' is "
+                  "unsupported. Expected: [{}]",
+                  current_version,
+                  [&]() {
+                    std::string versions;
+                    for (const auto& build : supported_builds) {
+                      if (!versions.empty()) versions += ", ";
+                      versions += build.second.title_version;
+                    }
+                    return versions;
+                  }()),
+      true, MESSAGE_TYPE_XNotify);
+#endif
+
   return false;
 }
 

--- a/src/xenia/hid/winkey/hookables/PerfectDarkZero.cc
+++ b/src/xenia/hid/winkey/hookables/PerfectDarkZero.cc
@@ -102,6 +102,12 @@ bool PerfectDarkZeroGame::IsGameSupported() {
       return true;
     }
   }
+#ifdef XENIA_MOUSEHOOK_MESSAGE
+  mousehook_message_wrapper(
+      "MOUSEHOOK: Supported Title ID, but unsupported version of PDZ, "
+      "refer to the Github repo for supported updates.",
+      true);
+#endif
 
   return false;
 }

--- a/src/xenia/hid/winkey/hookables/RDR.cc
+++ b/src/xenia/hid/winkey/hookables/RDR.cc
@@ -126,7 +126,22 @@ bool RedDeadRedemptionGame::IsGameSupported() {
       return true;
     }
   }
-
+#ifdef XENIA_MOUSEHOOK_MESSAGE
+  mousehook_message_wrapper(
+      std::format("MOUSEHOOK: Supported Title ID, but current version '{}' is "
+                  "unsupported. Expected: [{}]",
+                  current_version,
+                  [&]() {
+                    std::string versions;
+                    for (const auto& build : supported_builds) {
+                      if (!versions.empty()) versions += ", ";
+                      versions += build.title_version;
+                    }
+                    versions += ", GOTY TU0";
+                    return versions;
+                  }()),
+      true);
+#endif
   return false;
 }
 

--- a/src/xenia/hid/winkey/hookables/SaintsRow1.cc
+++ b/src/xenia/hid/winkey/hookables/SaintsRow1.cc
@@ -76,7 +76,7 @@ struct GameBuildAddrs {
 };
 
 std::map<SaintsRow1Game::GameBuild, GameBuildAddrs> supported_builds{
-    {SaintsRow1Game::GameBuild::Unknown, {" ", NULL, NULL}},
+    {SaintsRow1Game::GameBuild::Unknown, {"", NULL, NULL}},
     {SaintsRow1Game::GameBuild::SaintsRow1_TU1,
      {"1.0.1",    0x827f9af8, 0x827F9B00, 0x827F9BA4, 0x82F7EB04, 0x835F2B80,
       0x827CF9CC, 0x835F279B, 0x82EDE231, 0x82932407, 0x8283CA7B, 0x835F2883,
@@ -100,7 +100,21 @@ bool SaintsRow1Game::IsGameSupported() {
       return true;
     }
   }
-
+#ifdef XENIA_MOUSEHOOK_MESSAGE
+  mousehook_message_wrapper(
+      std::format("MOUSEHOOK: Supported Title ID, but current version '{}' is "
+                  "unsupported. Expected: [{}]",
+                  current_version,
+                  [&]() {
+                    std::string versions;
+                    for (const auto& build : supported_builds) {
+                      if (!versions.empty()) versions += ", ";
+                      versions += build.second.title_version;
+                    }
+                    return versions;
+                  }()),
+      true, MESSAGE_TYPE_XNotify);
+#endif
   return false;
 }
 

--- a/src/xenia/hid/winkey/hookables/SaintsRow2.cc
+++ b/src/xenia/hid/winkey/hookables/SaintsRow2.cc
@@ -81,7 +81,21 @@ bool SaintsRow2Game::IsGameSupported() {
       return true;
     }
   }
-
+#ifdef XENIA_MOUSEHOOK_MESSAGE
+  mousehook_message_wrapper(
+      std::format("MOUSEHOOK: Supported Title ID, but current version '{}' is "
+                  "unsupported. Expected: [{}]",
+                  current_version,
+                  [&]() {
+                    std::string versions;
+                    for (const auto& build : supported_builds) {
+                      if (!versions.empty()) versions += ", ";
+                      versions += build.second.title_version;
+                    }
+                    return versions;
+                  }()),
+      true, MESSAGE_TYPE_XNotify);
+#endif
   return false;
 }
 

--- a/src/xenia/hid/winkey/hookables/SourceEngine.cc
+++ b/src/xenia/hid/winkey/hookables/SourceEngine.cc
@@ -106,6 +106,22 @@ bool SourceEngine::IsGameSupported() {
     }
   }
 
+#ifdef XENIA_MOUSEHOOK_MESSAGE
+  mousehook_message_wrapper(
+      std::format("MOUSEHOOK: Supported Title ID, but current version '{}' is "
+                  "unsupported. Expected: [{}]",
+                  current_version,
+                  [&]() {
+                    std::string versions;
+                    for (const auto& build : supported_builds) {
+                      if (!versions.empty()) versions += ", ";
+                      versions += build.second.title_version;
+                    }
+                    return versions;
+                  }()),
+      true);
+#endif
+
   return false;
 }
 

--- a/src/xenia/hid/winkey/hookables/goldeneye.cc
+++ b/src/xenia/hid/winkey/hookables/goldeneye.cc
@@ -10,6 +10,7 @@
 #include "xenia/hid/winkey/hookables/goldeneye.h"
 
 #include "xenia/base/platform_win.h"
+#include "xenia/emulator.h"
 #include "xenia/hid/hid_flags.h"
 #include "xenia/hid/input_system.h"
 #include "xenia/kernel/util/shim_utils.h"
@@ -124,7 +125,12 @@ bool GoldeneyeGame::IsGameSupported() {
       return true;
     }
   }
-
+#ifdef XENIA_MOUSEHOOK_MESSAGE
+  mousehook_message_wrapper(
+      "MOUSEHOOK: Supported Title ID, but unsupported version of GE/PD, "
+      "refer to the Github repo for supported builds. ",
+      true);
+#endif
   return false;
 }
 

--- a/src/xenia/hid/winkey/hookables/halo3.cc
+++ b/src/xenia/hid/winkey/hookables/halo3.cc
@@ -101,7 +101,12 @@ bool Halo3Game::IsGameSupported() {
       return true;
     }
   }
-
+#ifdef XENIA_MOUSEHOOK_MESSAGE
+  mousehook_message_wrapper(
+      "MOUSEHOOK: Supported Title ID, but unsupported version of Halo, "
+      "refer to the Github repo for supported titles.",
+      true);
+#endif
   return false;
 }
 

--- a/src/xenia/hid/winkey/hookables/hookable_game.cc
+++ b/src/xenia/hid/winkey/hookables/hookable_game.cc
@@ -8,6 +8,7 @@
  */
 
 #include "xenia/hid/winkey/hookables/hookable_game.h"
+#include "xenia/emulator.h"
 #include "xenia/kernel/util/shim_utils.h"
 
 namespace xe {
@@ -30,7 +31,30 @@ xe::be<uint32_t>* multi_pointer(uint32_t base_address,
   }
   return current_pointer;
 }
+#ifdef XENIA_MOUSEHOOK_MESSAGE
+bool mousehook_message_wrapper(std::string message, bool handleseen,
+                               notification_type type, uint8_t pos) {
+  if (mousehook_message_read && handleseen) return false;
+  XELOGE(message);
+  const Emulator* emulator = xe::kernel::kernel_state()->emulator();
+  ui::ImGuiDrawer* imgui_drawer = emulator->imgui_drawer();
 
+  if (type == MESSAGE_TYPE_XNotify) {
+    new xe::ui::XNotifyWindow(imgui_drawer, "", message, 0, 2);
+  }
+  if (type == MESSAGE_TYPE_Host) {
+    ui::WindowedAppContext& app_context =
+        emulator->display_window()->app_context();
+    app_context.CallInUIThread([imgui_drawer, message, pos]() {
+      new xe::ui::HostNotificationWindow(imgui_drawer, "ERROR", message, 0,
+                                         pos);
+    });
+  }
+  if (!mousehook_message_read && handleseen) mousehook_message_read = true;
+
+  return true;
+}
+#endif
 }  // namespace winkey
 }  // namespace hid
 }  // namespace xe

--- a/src/xenia/hid/winkey/hookables/hookable_game.h
+++ b/src/xenia/hid/winkey/hookables/hookable_game.h
@@ -7,17 +7,21 @@
  ******************************************************************************
  */
 
+#define XENIA_MOUSEHOOK_MESSAGE
 #ifndef XENIA_HID_WINKEY_HOOKABLE_GAME_H_
 #define XENIA_HID_WINKEY_HOOKABLE_GAME_H_
 
 #include <vector>
 #include "xenia/hid/input.h"
 #include "xenia/xbox.h"
-
+#ifdef XENIA_MOUSEHOOK_MESSAGE
+#include "xenia/ui/imgui_guest_notification.h"
+#include "xenia/ui/imgui_host_notification.h"
+#endif
 namespace xe {
 namespace hid {
 namespace winkey {
-
+static bool mousehook_message_read;
 struct MouseEvent {
   int32_t x_delta = 0;
   int32_t y_delta = 0;
@@ -49,7 +53,16 @@ class HookableGame {
 
 xe::be<uint32_t>* multi_pointer(uint32_t base_address,
                                 std::vector<uint32_t> offsets);
+#ifdef XENIA_MOUSEHOOK_MESSAGE
+enum notification_type : uint8_t {
+  MESSAGE_TYPE_XNotify = 0,
+  MESSAGE_TYPE_Host = 1
+};
+bool mousehook_message_wrapper(std::string message, bool handleseen = true,
+                               notification_type type = MESSAGE_TYPE_Host,
+                               uint8_t pos = 2);
 
+#endif
 }  // namespace winkey
 }  // namespace hid
 }  // namespace xe


### PR DESCRIPTION
It mostly displays HostNotificationWindow for most games as XNotifyWindow doesn't fit for some games due to the update list being big,
Any hook's IsGameSupported that checks based on title update will notify the user of the required TU supported, other games have a different method of checking e.g Call Of Duty & Halo, so we show a generic message of 

> "MOUSEHOOK: Supported Title ID, but unsupported version of GAMENAME, refer to the Github repo for supported titles."

No message for the following games:

- GearsOfWars - I implemented IsGameSupported in kind of an odd way, and UE3/Gears needs a rewrite for overall to use multi-pointers.
- DeadRising - one of the current supported Dead Rising games does have a TU available but IsGameSupported returns supported when title ID is matching so there's no fail condition if the version is wrong.


![image](https://github.com/user-attachments/assets/a20f5a54-b2cf-4028-8c37-48773586d0d3)
some show XNotifyWindow
![xenia_canary_F7A7KQ2PZy](https://github.com/user-attachments/assets/2ac0c2c3-2bc5-4c9b-bfe9-b71db1681b23)
![xenia_canary_lgjwTvqJU5](https://github.com/user-attachments/assets/6416616a-5bf2-4f19-8105-192b6e17e9fc)
![image](https://github.com/user-attachments/assets/009f5282-84e7-4bf3-91de-9d586eacf1b2)

