### PR TITLE
MidHooks

### DIFF
--- a/src/xenia/cpu/ppc/ppc_frontend.cc
+++ b/src/xenia/cpu/ppc/ppc_frontend.cc
@@ -21,7 +21,7 @@
 namespace xe {
 namespace cpu {
 namespace ppc {
-
+extern uint32_t g_CurrentHookAddress;
 void InitializeIfNeeded();
 void CleanupOnShutdown();
 
@@ -56,8 +56,21 @@ Memory* PPCFrontend::memory() const { return processor_->memory(); }
 
 // Checks the state of the global lock and sets scratch to the current MSR
 // value.
-void MyHook(PPCContext* ppc_context, void* arg0, void* arg1) { printf("My Hook\n"); }
+using MouseHookMidHook = void (*)(PPCContext* context, void* arg0, void* arg1);
+std::unordered_map<uint32_t, std::vector<MouseHookMidHook>> g_AddressHooks;
 
+void RegisterAddressHook(uint32_t address, MouseHookMidHook hook_function) {
+    g_AddressHooks[address].push_back(hook_function);
+}
+void MyHook(PPCContext* ppc_context, void* arg0, void* arg1) {
+
+  auto it = g_AddressHooks.find(g_CurrentHookAddress);
+  if (it != g_AddressHooks.end()) {
+    for (auto& func : it->second) {
+      func(ppc_context, arg0, arg1);
+    }
+  }
+}
 void CheckGlobalLock(PPCContext* ppc_context, void* arg0, void* arg1) {
   auto global_mutex = reinterpret_cast<global_mutex_type*>(arg0);
   auto global_lock_count = reinterpret_cast<int32_t*>(arg1);

--- a/src/xenia/cpu/ppc/ppc_frontend.cc
+++ b/src/xenia/cpu/ppc/ppc_frontend.cc
@@ -21,7 +21,6 @@
 namespace xe {
 namespace cpu {
 namespace ppc {
-extern uint32_t g_CurrentHookAddress;
 void InitializeIfNeeded();
 void CleanupOnShutdown();
 
@@ -54,22 +53,25 @@ PPCFrontend::~PPCFrontend() {
 
 Memory* PPCFrontend::memory() const { return processor_->memory(); }
 
-// Checks the state of the global lock and sets scratch to the current MSR
-// value.
 using MouseHookMidHook = void (*)(PPCContext* context, void* arg0, void* arg1);
 std::unordered_map<uint32_t, std::vector<MouseHookMidHook>> g_AddressHooks;
 
 void RegisterMidHookASM(uint32_t address, MouseHookMidHook hook_function) {
+  XELOGW("RegisterMidHookASM: Hooking address {:08X}", address);
   g_AddressHooks[address].push_back(hook_function);
 }
 void MyHook(PPCContext* ppc_context, void* arg0, void* arg1) {
-  auto it = g_AddressHooks.find(g_CurrentHookAddress);
-  if (it != g_AddressHooks.end()) {
-    for (auto& func : it->second) {
-      func(ppc_context, arg0, arg1);
+  uint32_t hook_address = static_cast<uint32_t>(ppc_context->scratch);
+
+  if (auto it = g_AddressHooks.find(hook_address); it != g_AddressHooks.end()) {
+    for (const auto& hook_func : it->second) {
+      hook_func(ppc_context, arg0, arg1);
     }
   }
 }
+
+// Checks the state of the global lock and sets scratch to the current MSR
+// value.
 void CheckGlobalLock(PPCContext* ppc_context, void* arg0, void* arg1) {
   auto global_mutex = reinterpret_cast<global_mutex_type*>(arg0);
   auto global_lock_count = reinterpret_cast<int32_t*>(arg1);

--- a/src/xenia/cpu/ppc/ppc_frontend.cc
+++ b/src/xenia/cpu/ppc/ppc_frontend.cc
@@ -56,6 +56,8 @@ Memory* PPCFrontend::memory() const { return processor_->memory(); }
 
 // Checks the state of the global lock and sets scratch to the current MSR
 // value.
+void MyHook(PPCContext* ppc_context, void* arg0, void* arg1) { printf("My Hook\n"); }
+
 void CheckGlobalLock(PPCContext* ppc_context, void* arg0, void* arg1) {
   auto global_mutex = reinterpret_cast<global_mutex_type*>(arg0);
   auto global_lock_count = reinterpret_cast<int32_t*>(arg1);
@@ -94,6 +96,7 @@ void SyscallHandler(PPCContext* ppc_context, void* arg0, void* arg1) {
 bool PPCFrontend::Initialize() {
   void* arg0 = reinterpret_cast<void*>(&xe::global_critical_region::mutex());
   void* arg1 = reinterpret_cast<void*>(&builtins_.global_lock_count);
+  builtins_.my_hook = processor_->DefineBuiltin("MyHook", MyHook, arg0, arg1);
   builtins_.check_global_lock =
       processor_->DefineBuiltin("CheckGlobalLock", CheckGlobalLock, arg0, arg1);
   builtins_.enter_global_lock =

--- a/src/xenia/cpu/ppc/ppc_frontend.cc
+++ b/src/xenia/cpu/ppc/ppc_frontend.cc
@@ -59,11 +59,10 @@ Memory* PPCFrontend::memory() const { return processor_->memory(); }
 using MouseHookMidHook = void (*)(PPCContext* context, void* arg0, void* arg1);
 std::unordered_map<uint32_t, std::vector<MouseHookMidHook>> g_AddressHooks;
 
-void RegisterAddressHook(uint32_t address, MouseHookMidHook hook_function) {
-    g_AddressHooks[address].push_back(hook_function);
+void RegisterMidHookASM(uint32_t address, MouseHookMidHook hook_function) {
+  g_AddressHooks[address].push_back(hook_function);
 }
 void MyHook(PPCContext* ppc_context, void* arg0, void* arg1) {
-
   auto it = g_AddressHooks.find(g_CurrentHookAddress);
   if (it != g_AddressHooks.end()) {
     for (auto& func : it->second) {

--- a/src/xenia/cpu/ppc/ppc_frontend.h
+++ b/src/xenia/cpu/ppc/ppc_frontend.h
@@ -34,6 +34,7 @@ struct PPCBuiltins {
   Function* enter_global_lock;
   Function* leave_global_lock;
   Function* syscall_handler;
+  Function* my_hook;
 };
 
 class PPCFrontend {

--- a/src/xenia/cpu/ppc/ppc_hir_builder.cc
+++ b/src/xenia/cpu/ppc/ppc_hir_builder.cc
@@ -38,13 +38,9 @@ namespace xe {
 namespace cpu {
 namespace ppc {
 uint32_t g_CurrentHookAddress = 0;
- bool addshit = false;
 using MouseHookMidHook = void (*)(PPCContext* context, void* arg0, void* arg1);
 extern std::unordered_map<uint32_t, std::vector<MouseHookMidHook>>
     g_AddressHooks;
-
-extern void RegisterAddressHook(uint32_t address,
-                                MouseHookMidHook hook_function);
 
 // TODO(benvanik): remove when enums redefined.
 using namespace xe::cpu::hir;
@@ -89,21 +85,10 @@ void PPCHIRBuilder::Reset() {
   with_debug_info_ = false;
   HIRBuilder::Reset();
 }
-void MyCustomHook(PPCContext* context, void* arg0, void* arg1) {
-  printf("LOL HOKOED");
-}
 bool PPCHIRBuilder::Emit(GuestFunction* function, uint32_t flags) {
   SCOPE_profile_cpu_f("cpu");
 
   Memory* memory = frontend_->memory();
-  if (!addshit) {
-
-
-    RegisterAddressHook(0x82646240, MyCustomHook);
-
-
-    addshit = true;
-  }
   function_ = function;
   start_address_ = function_->address();
   // chrispy: i've seen this one happen, not sure why but i think from trying to

--- a/src/xenia/cpu/ppc/ppc_hir_builder.cc
+++ b/src/xenia/cpu/ppc/ppc_hir_builder.cc
@@ -171,7 +171,8 @@ bool PPCHIRBuilder::Emit(GuestFunction* function, uint32_t flags) {
     if (opcode_info.type == PPCOpcodeType::kSync) {
       ContextBarrier();
     }
-
+    if (address == 0x82646240)
+    CallExtern(builtins()->my_hook);
     MaybeBreakOnInstruction(address);
 
     InstrData i;

--- a/src/xenia/cpu/ppc/ppc_hir_builder.cc
+++ b/src/xenia/cpu/ppc/ppc_hir_builder.cc
@@ -37,7 +37,6 @@ DEFINE_bool(
 namespace xe {
 namespace cpu {
 namespace ppc {
-uint32_t g_CurrentHookAddress = 0;
 using MouseHookMidHook = void (*)(PPCContext* context, void* arg0, void* arg1);
 extern std::unordered_map<uint32_t, std::vector<MouseHookMidHook>>
     g_AddressHooks;
@@ -175,7 +174,10 @@ bool PPCHIRBuilder::Emit(GuestFunction* function, uint32_t flags) {
     }
 
     if (g_AddressHooks.find(address) != g_AddressHooks.end()) {
-      g_CurrentHookAddress = address;
+      // Store the current address in scratch before calling the hook
+      auto store_addr = LoadConstantUint32(address);
+      StoreContext(offsetof(PPCContext, scratch),
+                   ZeroExtend(store_addr, INT64_TYPE));
       CallExtern(builtins()->my_hook);
     }
     MaybeBreakOnInstruction(address);

--- a/src/xenia/cpu/ppc/ppc_hir_builder.cc
+++ b/src/xenia/cpu/ppc/ppc_hir_builder.cc
@@ -37,6 +37,14 @@ DEFINE_bool(
 namespace xe {
 namespace cpu {
 namespace ppc {
+uint32_t g_CurrentHookAddress = 0;
+ bool addshit = false;
+using MouseHookMidHook = void (*)(PPCContext* context, void* arg0, void* arg1);
+extern std::unordered_map<uint32_t, std::vector<MouseHookMidHook>>
+    g_AddressHooks;
+
+extern void RegisterAddressHook(uint32_t address,
+                                MouseHookMidHook hook_function);
 
 // TODO(benvanik): remove when enums redefined.
 using namespace xe::cpu::hir;
@@ -81,12 +89,21 @@ void PPCHIRBuilder::Reset() {
   with_debug_info_ = false;
   HIRBuilder::Reset();
 }
-
+void MyCustomHook(PPCContext* context, void* arg0, void* arg1) {
+  printf("LOL HOKOED");
+}
 bool PPCHIRBuilder::Emit(GuestFunction* function, uint32_t flags) {
   SCOPE_profile_cpu_f("cpu");
 
   Memory* memory = frontend_->memory();
+  if (!addshit) {
 
+
+    RegisterAddressHook(0x82646240, MyCustomHook);
+
+
+    addshit = true;
+  }
   function_ = function;
   start_address_ = function_->address();
   // chrispy: i've seen this one happen, not sure why but i think from trying to
@@ -171,8 +188,11 @@ bool PPCHIRBuilder::Emit(GuestFunction* function, uint32_t flags) {
     if (opcode_info.type == PPCOpcodeType::kSync) {
       ContextBarrier();
     }
-    if (address == 0x82646240)
-    CallExtern(builtins()->my_hook);
+
+    if (g_AddressHooks.find(address) != g_AddressHooks.end()) {
+      g_CurrentHookAddress = address;
+      CallExtern(builtins()->my_hook);
+    }
     MaybeBreakOnInstruction(address);
 
     InstrData i;

--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -113,6 +113,8 @@ DECLARE_int32(user_language);
 DECLARE_bool(allow_plugins);
 DECLARE_bool(disable_autoaim);
 
+DECLARE_bool(internal_hook);
+
 DEFINE_int32(priority_class, 0,
              "Forces Xenia to use different process priority than default one. "
              "It might affect performance and cause unexpected bugs. Possible "
@@ -1779,9 +1781,11 @@ X_STATUS Emulator::CompleteLaunch(const std::filesystem::path& path,
         continue;
       }
       // Write beNOP to each write address
-      patch_addr(build.mousefix_addr1, build.beNOP);
-      patch_addr(build.mousefix_addr2, build.beNOP);
-      patch_addr(build.mousefix_addr3, build.beNOP);
+      if (!cvars::internal_hook) {
+        patch_addr(build.mousefix_addr1, build.beNOP);
+        patch_addr(build.mousefix_addr2, build.beNOP);
+        patch_addr(build.mousefix_addr3, build.beNOP);
+      }
       if (cvars::disable_autoaim && build.aim_assist_xbtl) {
         patch_addr(build.aim_assist_xbtl, build.beNOP);
       }

--- a/src/xenia/hid/winkey/hookables/CallOfDuty.cc
+++ b/src/xenia/hid/winkey/hookables/CallOfDuty.cc
@@ -358,6 +358,9 @@ bool CallOfDutyGame::Dvar_GetBool(std::string dvar, uint32_t dvar_address) {
 
   return state;
 }
+void CallOfDutyGame::MidHookInit() {
+  if (midhook_status == HOOKED) return;
+}
 }  // namespace winkey
 }  // namespace hid
 }  // namespace xe

--- a/src/xenia/hid/winkey/hookables/CallOfDuty.h
+++ b/src/xenia/hid/winkey/hookables/CallOfDuty.h
@@ -84,6 +84,8 @@ class CallOfDutyGame : public HookableGame {
 
   bool Dvar_GetBool(std::string dvar, uint32_t dvar_address);
 
+  void MidHookInit();
+
  private:
   GameBuild game_build_ = GameBuild::Unknown;
 };

--- a/src/xenia/hid/winkey/hookables/Crackdown2.cc
+++ b/src/xenia/hid/winkey/hookables/Crackdown2.cc
@@ -157,7 +157,9 @@ void Crackdown2Game::WeaponSwitchHandler(uint32_t user_index,
                                          RawInputState& input_state,
                                          X_INPUT_STATE* out_state, int weapon,
                                          uint16_t buttons) {}
-
+void Crackdown2Game::MidHookInit() {
+  if (midhook_status == HOOKED) return;
+}
 }  // namespace winkey
 }  // namespace hid
 }  // namespace xe

--- a/src/xenia/hid/winkey/hookables/Crackdown2.h
+++ b/src/xenia/hid/winkey/hookables/Crackdown2.h
@@ -39,6 +39,8 @@ class Crackdown2Game : public HookableGame {
                            X_INPUT_STATE* out_state, int weapon,
                            uint16_t buttons);
 
+  void MidHookInit();
+
  private:
   GameBuild game_build_ = GameBuild::Unknown;
 };

--- a/src/xenia/hid/winkey/hookables/DeadRising.cc
+++ b/src/xenia/hid/winkey/hookables/DeadRising.cc
@@ -159,7 +159,9 @@ void DeadRisingGame::WeaponSwitchHandler(uint32_t user_index,
                                          RawInputState& input_state,
                                          X_INPUT_STATE* out_state, int weapon,
                                          uint16_t buttons) {}
-
+void DeadRisingGame::MidHookInit() {
+  if (midhook_status == HOOKED) return;
+}
 }  // namespace winkey
 }  // namespace hid
 }  // namespace xe

--- a/src/xenia/hid/winkey/hookables/DeadRising.h
+++ b/src/xenia/hid/winkey/hookables/DeadRising.h
@@ -39,6 +39,8 @@ class DeadRisingGame : public HookableGame {
                            X_INPUT_STATE* out_state, int weapon,
                            uint16_t buttons);
 
+  void MidHookInit();
+
  private:
   GameBuild game_build_ = GameBuild::Unknown;
 };

--- a/src/xenia/hid/winkey/hookables/Farcry.cc
+++ b/src/xenia/hid/winkey/hookables/Farcry.cc
@@ -148,7 +148,9 @@ void FarCryGame::WeaponSwitchHandler(uint32_t user_index,
                                      RawInputState& input_state,
                                      X_INPUT_STATE* out_state, int weapon,
                                      uint16_t buttons) {}
-
+void FarCryGame::MidHookInit() {
+  if (midhook_status == HOOKED) return;
+}
 }  // namespace winkey
 }  // namespace hid
 }  // namespace xe

--- a/src/xenia/hid/winkey/hookables/Farcry.h
+++ b/src/xenia/hid/winkey/hookables/Farcry.h
@@ -36,6 +36,8 @@ class FarCryGame : public HookableGame {
                            X_INPUT_STATE* out_state, int weapon,
                            uint16_t buttons);
 
+  void MidHookInit();
+
  private:
   GameBuild game_build_ = GameBuild::Unknown;
 };

--- a/src/xenia/hid/winkey/hookables/GearsOfWars.cc
+++ b/src/xenia/hid/winkey/hookables/GearsOfWars.cc
@@ -440,7 +440,9 @@ void GearsOfWarsGame::WeaponSwitchHandler(uint32_t user_index,
                                           RawInputState& input_state,
                                           X_INPUT_STATE* out_state, int weapon,
                                           uint16_t buttons) {}
-
+void GearsOfWarsGame::MidHookInit() {
+  if (midhook_status == HOOKED) return;
+}
 }  // namespace winkey
 }  // namespace hid
 }  // namespace xe

--- a/src/xenia/hid/winkey/hookables/GearsOfWars.h
+++ b/src/xenia/hid/winkey/hookables/GearsOfWars.h
@@ -55,6 +55,8 @@ class GearsOfWarsGame : public HookableGame {
                            X_INPUT_STATE* out_state, int weapon,
                            uint16_t buttons);
 
+  void MidHookInit();
+
  private:
   GameBuild game_build_ = GameBuild::Unknown;
   // Timer variables to hold the state for a while // this is probably not ideal

--- a/src/xenia/hid/winkey/hookables/JustCause.cc
+++ b/src/xenia/hid/winkey/hookables/JustCause.cc
@@ -164,7 +164,9 @@ void JustCauseGame::WeaponSwitchHandler(uint32_t user_index,
                                         RawInputState& input_state,
                                         X_INPUT_STATE* out_state, int weapon,
                                         uint16_t buttons) {}
-
+void JustCauseGame::MidHookInit() {
+  if (midhook_status == HOOKED) return;
+}
 }  // namespace winkey
 }  // namespace hid
 }  // namespace xe

--- a/src/xenia/hid/winkey/hookables/JustCause.h
+++ b/src/xenia/hid/winkey/hookables/JustCause.h
@@ -39,6 +39,8 @@ class JustCauseGame : public HookableGame {
                            X_INPUT_STATE* out_state, int weapon,
                            uint16_t buttons);
 
+  void MidHookInit();
+
  private:
   GameBuild game_build_ = GameBuild::Unknown;
 };

--- a/src/xenia/hid/winkey/hookables/Minecraft.cc
+++ b/src/xenia/hid/winkey/hookables/Minecraft.cc
@@ -320,7 +320,9 @@ void MinecraftGame::WeaponSwitchHandler(uint32_t user_index,
     }
   }
 }
-
+void MinecraftGame::MidHookInit() {
+  if (midhook_status == HOOKED) return;
+}
 }  // namespace winkey
 }  // namespace hid
 }  // namespace xe

--- a/src/xenia/hid/winkey/hookables/Minecraft.h
+++ b/src/xenia/hid/winkey/hookables/Minecraft.h
@@ -32,6 +32,8 @@ class MinecraftGame : public HookableGame {
                            X_INPUT_STATE* out_state, int weapon,
                            uint16_t buttons);
 
+  void MidHookInit();
+
  private:
   GameBuild game_build_ = GameBuild::Unknown;
 };

--- a/src/xenia/hid/winkey/hookables/PerfectDarkZero.cc
+++ b/src/xenia/hid/winkey/hookables/PerfectDarkZero.cc
@@ -531,6 +531,9 @@ void PerfectDarkZeroGame::WeaponSwitchHandler(uint32_t user_index,
                                               RawInputState& input_state,
                                               X_INPUT_STATE* out_state,
                                               int weapon, uint16_t buttons) {}
+void PerfectDarkZeroGame::MidHookInit() {
+  if (midhook_status == HOOKED) return;
+}
 }  // namespace winkey
 }  // namespace hid
 }  // namespace xe

--- a/src/xenia/hid/winkey/hookables/PerfectDarkZero.h
+++ b/src/xenia/hid/winkey/hookables/PerfectDarkZero.h
@@ -52,6 +52,8 @@ class PerfectDarkZeroGame : public HookableGame {
                            X_INPUT_STATE* out_state, int weapon,
                            uint16_t buttons);
 
+  void MidHookInit();
+
  private:
   GameBuild game_build_ = GameBuild::Unknown;
 

--- a/src/xenia/hid/winkey/hookables/RDR.cc
+++ b/src/xenia/hid/winkey/hookables/RDR.cc
@@ -872,7 +872,9 @@ void RedDeadRedemptionGame::WeaponSwitchHandler(uint32_t user_index,
                                                 RawInputState& input_state,
                                                 X_INPUT_STATE* out_state,
                                                 int weapon, uint16_t buttons) {}
-
+void RedDeadRedemptionGame::MidHookInit() {
+  if (midhook_status == HOOKED) return;
+}
 }  // namespace winkey
 }  // namespace hid
 }  // namespace xe

--- a/src/xenia/hid/winkey/hookables/RDR.h
+++ b/src/xenia/hid/winkey/hookables/RDR.h
@@ -66,6 +66,8 @@ class RedDeadRedemptionGame : public HookableGame {
                            X_INPUT_STATE* out_state, int weapon,
                            uint16_t buttons);
 
+  void MidHookInit();
+
  private:
   GameBuild game_build_ = GameBuild::Unknown;
   std::chrono::steady_clock::time_point last_movement_time_x_;

--- a/src/xenia/hid/winkey/hookables/SaintsRow1.cc
+++ b/src/xenia/hid/winkey/hookables/SaintsRow1.cc
@@ -146,9 +146,18 @@ float SaintsRow1Game::DegreetoRadians(float degree) {
 float SaintsRow1Game::RadianstoDegree(float radians) {
   return (float)(radians * (180 / M_PI));
 }
-
+static std::mutex input_mutex;
 bool SaintsRow1Game::DoHooks(uint32_t user_index, RawInputState& input_state,
                              X_INPUT_STATE* out_state) {
+
+  {
+    std::lock_guard<std::mutex> lock(input_mutex);
+    static_state.mouse = input_state.mouse;
+  }
+  if (!IsGameSupported()) {
+    return false;
+  }
+
   if (supported_builds.count(game_build_) == 0) {
     return false;
   }
@@ -310,10 +319,10 @@ bool SaintsRow1Game::DoHooks(uint32_t user_index, RawInputState& input_state,
         ((input_state.mouse.x_delta / divider_x) * (float)cvars::sensitivity) /
         frametime;
   }
-  if (!(isTervelPlugin() && inFirstPerson()))
+  /*if (!(isTervelPlugin() && inFirstPerson()))
     *addition_x = degree_x;
   else if (*fine_aim_x != NULL)
-    *fine_aim_x = DegreetoRadians(degree_x);
+    *fine_aim_x = DegreetoRadians(degree_x);*/
 
   float delta_y =
       (input_state.mouse.y_delta / divider_y) * (float)cvars::sensitivity;
@@ -709,7 +718,12 @@ void SaintsRow1Game::WeaponSwitchHandler(uint32_t user_index,
 // can't be in class because it'd pass in `this`
 void print_x_axis_midhook(PPCContext* context, void* arg0, void* arg1) {
   printf("X-axis: %f \n", context->f[30]);
-  // context->f[30] = 0.0;
+  double delta = 0.0;
+      {
+        std::lock_guard<std::mutex> lock(input_mutex);
+        delta = static_state.mouse.x_delta / 1000.0;
+    }
+      context->f[30] = context->f[30] + delta;
 }
 void SaintsRow1Game::MidHookInit() {
   if (midhook_status == HOOKED) return;

--- a/src/xenia/hid/winkey/hookables/SaintsRow1.cc
+++ b/src/xenia/hid/winkey/hookables/SaintsRow1.cc
@@ -29,6 +29,7 @@ DECLARE_bool(invert_x);
 DECLARE_double(right_stick_hold_time_workaround);
 DECLARE_bool(swap_wheel);
 DECLARE_double(menu_sensitivity);
+DECLARE_bool(internal_hook);
 
 const uint32_t kTitleIdSaintsRow1Global = 0x545107D1;
 const uint32_t kTitleIdSaintsRow1JP = 0x545107F8;
@@ -74,8 +75,9 @@ struct GameBuildAddrs {
   uint32_t customization_screen_zoom_level_addr;
   uint32_t mp_flag_1;
   uint32_t mp_flag_2;
+  uint32_t radian_x_axis_midhook_addr1;
 };
-
+SaintsRow1Game* SaintsRow1Game::current_instance_ = nullptr;
 std::map<SaintsRow1Game::GameBuild, GameBuildAddrs> supported_builds{
     {SaintsRow1Game::GameBuild::Unknown, {"", NULL, NULL}},
     {SaintsRow1Game::GameBuild::SaintsRow1_TU1,
@@ -83,13 +85,13 @@ std::map<SaintsRow1Game::GameBuild, GameBuildAddrs> supported_builds{
       0x827CF9CC, 0x835F279B, 0x82EDE231, 0x82932407, 0x8283CA7B, 0x835F2883,
       0x82EE12F4, 0x835F2884, 0x835F27A3, 0x835F2527, 0x827CA69C, 0x827F9AD8,
       0x827F9B58, 0x827F99A3, 0x827F956C, 0x822AEB78, 0x822ADC10, 0x827D0484,
-      0x835F1A58, 0x837DD080, 0x827F95B4, 0x835F33DF, 0x835F3522}},
+      0x835F1A58, 0x837DD080, 0x827F95B4, 0x835F33DF, 0x835F3522, 0x8211D3E8}},
     {SaintsRow1Game::GameBuild::SaintsRow1_JP,
      {"0.0.0.1",  0x827E9BF8, 0x827E9C00, 0x827E9CA4, 0x82F6E69C, 0x835E2718,
       0x827BFAD0, 0x835E232F, 0x82EE2566, 0x82922507, 0x8282CB7B, 0x835E241B,
       0x82ED13AC, 0x835E241C, 0x835E233B, 0x835E20C7, 0x827BA764, 0x827E9BD8,
       0x827E9C58, 0x827E9AA3, 0x827E966C, 0x822AD718, 0x822AC730, 0x827C058C,
-      0x835E15F0, 0x837CCC10, 0x827E96B4, 0x835E2F6E, 0x835E2F6F}}};
+      0x835E15F0, 0x837CCC10, 0x827E96B4, 0x835E2F6E, 0x835E2F6F, 0x8211D428}}};
 SaintsRow1Game::~SaintsRow1Game() = default;
 std::map<std::pair<uint32_t, std::string>, SaintsRow1Game::GameBuild>
     supported_builds_lookup{{{kTitleIdSaintsRow1Global, "0.0.1.1"},
@@ -151,7 +153,6 @@ bool SaintsRow1Game::DoHooks(uint32_t user_index, RawInputState& input_state,
   if (supported_builds.count(game_build_) == 0) {
     return false;
   }
-  mouse_x_ld += input_state.mouse.x_delta;
   // xtbl edits can't be made into a patch most likely?
   xe::be<float>* ingamesens_x =
       kernel_memory()->TranslateVirtual<xe::be<float>*>(
@@ -309,11 +310,11 @@ bool SaintsRow1Game::DoHooks(uint32_t user_index, RawInputState& input_state,
         ((input_state.mouse.x_delta / divider_x) * (float)cvars::sensitivity) /
         frametime;
   }
-  /*if (!(isTervelPlugin() && inFirstPerson()))
+  if (!cvars::internal_hook && !(isTervelPlugin() && inFirstPerson()))
     *addition_x = degree_x;
-  else if (*fine_aim_x != NULL)
-    *fine_aim_x = DegreetoRadians(degree_x);*/
-
+  else if (fine_aim_x != NULL && (isTervelPlugin() && inFirstPerson()))
+    *fine_aim_x = DegreetoRadians(degree_x);
+  mouse_x_ld += input_state.mouse.x_delta;
   float delta_y =
       (input_state.mouse.y_delta / divider_y) * (float)cvars::sensitivity;
 
@@ -705,14 +706,50 @@ void SaintsRow1Game::WeaponSwitchHandler(uint32_t user_index,
         supported_builds[game_build_].change_weapon_function_addr);
   }
 }
+
+constexpr double deg_to_rad(double degrees) { return degrees * M_PI / 180.0; }
+
+constexpr double rad_to_deg(double radians) { return radians * 180.0 / M_PI; }
+
 // can't be in class because it'd pass in `this`
 void print_x_axis_midhook(PPCContext* context, void* arg0, void* arg1) {
+  return;
   context->f[30] = context->f[30] + (mouse_x_ld / 1250.0);
   mouse_x_ld = 0;
 }
+
+void x_addition_hook(PPCContext* context, void* arg0, void* arg1) {
+  if (cvars::internal_hook == false) return;
+  double divider = 15.0;
+  if (SaintsRow1Game::current_instance_) {
+    xe::be<float>* current_fov =
+        kernel_memory()->TranslateVirtual<xe::be<float>*>(
+            supported_builds[SaintsRow1Game::current_instance_->game_build_]
+                .current_fov_address);
+    float fov = *current_fov;
+    if (fov < 60.f) {
+      fov = 60.f / fov;
+      divider = divider * fov;
+    }
+  }
+
+  double degrees = rad_to_deg(context->f[27]);
+  degrees = degrees + (mouse_x_ld / divider);
+  context->f[27] = context->f[27] + deg_to_rad(degrees);
+  mouse_x_ld = 0;
+}
+
 void SaintsRow1Game::MidHookInit() {
-  if (midhook_status == HOOKED) return;
-  xe::cpu::ppc::RegisterMidHookASM(0x8211D96C, print_x_axis_midhook);
+  if (midhook_status == HOOKED || !cvars::internal_hook) return;
+  SaintsRow1Game::current_instance_ = this;
+
+  if (!supported_builds[game_build_].radian_x_axis_midhook_addr1) return;
+  current_instance_ = this;
+
+  xe::cpu::ppc::RegisterMidHookASM(
+      supported_builds[game_build_].radian_x_axis_midhook_addr1,
+      x_addition_hook);
+
   midhook_status = HOOKED;
 }
 

--- a/src/xenia/hid/winkey/hookables/SaintsRow1.cc
+++ b/src/xenia/hid/winkey/hookables/SaintsRow1.cc
@@ -146,16 +146,8 @@ float SaintsRow1Game::DegreetoRadians(float degree) {
 float SaintsRow1Game::RadianstoDegree(float radians) {
   return (float)(radians * (180 / M_PI));
 }
-static std::mutex input_mutex;
 bool SaintsRow1Game::DoHooks(uint32_t user_index, RawInputState& input_state,
                              X_INPUT_STATE* out_state) {
-  {
-    static_state.mouse = input_state.mouse;
-  }
-  if (!IsGameSupported()) {
-    return false;
-  }
-
   if (supported_builds.count(game_build_) == 0) {
     return false;
   }

--- a/src/xenia/hid/winkey/hookables/SaintsRow1.cc
+++ b/src/xenia/hid/winkey/hookables/SaintsRow1.cc
@@ -149,9 +149,7 @@ float SaintsRow1Game::RadianstoDegree(float radians) {
 static std::mutex input_mutex;
 bool SaintsRow1Game::DoHooks(uint32_t user_index, RawInputState& input_state,
                              X_INPUT_STATE* out_state) {
-
   {
-    std::lock_guard<std::mutex> lock(input_mutex);
     static_state.mouse = input_state.mouse;
   }
   if (!IsGameSupported()) {
@@ -161,7 +159,7 @@ bool SaintsRow1Game::DoHooks(uint32_t user_index, RawInputState& input_state,
   if (supported_builds.count(game_build_) == 0) {
     return false;
   }
-
+  mouse_x_ld += input_state.mouse.x_delta;
   // xtbl edits can't be made into a patch most likely?
   xe::be<float>* ingamesens_x =
       kernel_memory()->TranslateVirtual<xe::be<float>*>(
@@ -717,13 +715,8 @@ void SaintsRow1Game::WeaponSwitchHandler(uint32_t user_index,
 }
 // can't be in class because it'd pass in `this`
 void print_x_axis_midhook(PPCContext* context, void* arg0, void* arg1) {
-  printf("X-axis: %f \n", context->f[30]);
-  double delta = 0.0;
-      {
-        std::lock_guard<std::mutex> lock(input_mutex);
-        delta = static_state.mouse.x_delta / 1000.0;
-    }
-      context->f[30] = context->f[30] + delta;
+  context->f[30] = context->f[30] + (mouse_x_ld / 1250.0);
+  mouse_x_ld = 0;
 }
 void SaintsRow1Game::MidHookInit() {
   if (midhook_status == HOOKED) return;

--- a/src/xenia/hid/winkey/hookables/SaintsRow1.cc
+++ b/src/xenia/hid/winkey/hookables/SaintsRow1.cc
@@ -706,6 +706,16 @@ void SaintsRow1Game::WeaponSwitchHandler(uint32_t user_index,
         supported_builds[game_build_].change_weapon_function_addr);
   }
 }
+// can't be in class because it'd pass in `this`
+void print_x_axis_midhook(PPCContext* context, void* arg0, void* arg1) {
+  printf("X-axis: %f \n", context->f[30]);
+  // context->f[30] = 0.0;
+}
+void SaintsRow1Game::MidHookInit() {
+  if (midhook_status == HOOKED) return;
+  xe::cpu::ppc::RegisterMidHookASM(0x8211D96C, print_x_axis_midhook);
+  midhook_status = HOOKED;
+}
 
 }  // namespace winkey
 }  // namespace hid

--- a/src/xenia/hid/winkey/hookables/SaintsRow1.h
+++ b/src/xenia/hid/winkey/hookables/SaintsRow1.h
@@ -49,6 +49,7 @@ class SaintsRow1Game : public HookableGame {
   void WeaponSwitchHandler(uint32_t user_index, RawInputState& input_state,
                            X_INPUT_STATE* out_state, int weapon,
                            uint16_t buttons);
+  void MidHookInit();
 
  private:
   GameBuild game_build_ = GameBuild::Unknown;

--- a/src/xenia/hid/winkey/hookables/SaintsRow1.h
+++ b/src/xenia/hid/winkey/hookables/SaintsRow1.h
@@ -50,9 +50,10 @@ class SaintsRow1Game : public HookableGame {
                            X_INPUT_STATE* out_state, int weapon,
                            uint16_t buttons);
   void MidHookInit();
+  static SaintsRow1Game* current_instance_;
+  GameBuild game_build_ = GameBuild::Unknown;
 
  private:
-  GameBuild game_build_ = GameBuild::Unknown;
   // Timer variables to hold the state for a while // this is probably not ideal
   // -Clippy95
   std::chrono::steady_clock::time_point last_movement_time_x_;

--- a/src/xenia/hid/winkey/hookables/SaintsRow1.h
+++ b/src/xenia/hid/winkey/hookables/SaintsRow1.h
@@ -16,7 +16,7 @@
 namespace xe {
 namespace hid {
 namespace winkey {
-
+static int32_t mouse_x_ld;
 class SaintsRow1Game : public HookableGame {
  public:
   enum class GameBuild { Unknown, SaintsRow1_TU1, SaintsRow1_JP };

--- a/src/xenia/hid/winkey/hookables/SaintsRow2.cc
+++ b/src/xenia/hid/winkey/hookables/SaintsRow2.cc
@@ -349,7 +349,9 @@ uint64_t SaintsRow2Game::reset_fineaim(uint32_t function_address,
 
   return return_value != 0;
 }
-
+void SaintsRow2Game::MidHookInit() {
+  if (midhook_status == HOOKED) return;
+}
 }  // namespace winkey
 }  // namespace hid
 }  // namespace xe

--- a/src/xenia/hid/winkey/hookables/SaintsRow2.h
+++ b/src/xenia/hid/winkey/hookables/SaintsRow2.h
@@ -43,6 +43,8 @@ class SaintsRow2Game : public HookableGame {
   uint64_t reset_fineaim(uint32_t function_address, uint32_t player_ptr,
                          uint32_t a2, uint32_t a3);
 
+  void MidHookInit();
+
  private:
   GameBuild game_build_ = GameBuild::Unknown;
 

--- a/src/xenia/hid/winkey/hookables/SourceEngine.cc
+++ b/src/xenia/hid/winkey/hookables/SourceEngine.cc
@@ -290,7 +290,9 @@ void SourceEngine::WeaponSwitchHandler(uint32_t user_index,
                                        RawInputState& input_state,
                                        X_INPUT_STATE* out_state, int weapon,
                                        uint16_t buttons) {}
-
+void SourceEngine::MidHookInit() {
+  if (midhook_status == HOOKED) return;
+}
 }  // namespace winkey
 }  // namespace hid
 }  // namespace xe

--- a/src/xenia/hid/winkey/hookables/SourceEngine.h
+++ b/src/xenia/hid/winkey/hookables/SourceEngine.h
@@ -47,6 +47,8 @@ class SourceEngine : public HookableGame {
                            X_INPUT_STATE* out_state, int weapon,
                            uint16_t buttons);
 
+  void MidHookInit();
+
  private:
   GameBuild game_build_ = GameBuild::Unknown;
 

--- a/src/xenia/hid/winkey/hookables/goldeneye.cc
+++ b/src/xenia/hid/winkey/hookables/goldeneye.cc
@@ -574,7 +574,9 @@ void GoldeneyeGame::WeaponSwitchHandler(uint32_t user_index,
                                         RawInputState& input_state,
                                         X_INPUT_STATE* out_state, int weapon,
                                         uint16_t buttons) {}
-
+void GoldeneyeGame::MidHookInit() {
+  if (midhook_status == HOOKED) return;
+}
 }  // namespace winkey
 }  // namespace hid
 }  // namespace xe

--- a/src/xenia/hid/winkey/hookables/goldeneye.h
+++ b/src/xenia/hid/winkey/hookables/goldeneye.h
@@ -44,6 +44,8 @@ class GoldeneyeGame : public HookableGame {
                            X_INPUT_STATE* out_state, int weapon,
                            uint16_t buttons);
 
+  void MidHookInit();
+
  private:
   GameBuild game_build_ = GameBuild::Unknown;
 

--- a/src/xenia/hid/winkey/hookables/halo3.cc
+++ b/src/xenia/hid/winkey/hookables/halo3.cc
@@ -185,7 +185,9 @@ void Halo3Game::WeaponSwitchHandler(uint32_t user_index,
                                     RawInputState& input_state,
                                     X_INPUT_STATE* out_state, int weapon,
                                     uint16_t buttons) {}
-
+void Halo3Game::MidHookInit() {
+  if (midhook_status == HOOKED) return;
+}
 }  // namespace winkey
 }  // namespace hid
 }  // namespace xe

--- a/src/xenia/hid/winkey/hookables/halo3.h
+++ b/src/xenia/hid/winkey/hookables/halo3.h
@@ -59,6 +59,8 @@ class Halo3Game : public HookableGame {
                            X_INPUT_STATE* out_state, int weapon,
                            uint16_t buttons);
 
+  void MidHookInit();
+
  private:
   GameBuild game_build_ = GameBuild::Unknown;
 };

--- a/src/xenia/hid/winkey/hookables/hookable_game.h
+++ b/src/xenia/hid/winkey/hookables/hookable_game.h
@@ -12,6 +12,7 @@
 #define XENIA_HID_WINKEY_HOOKABLE_GAME_H_
 
 #include <vector>
+#include "xenia/cpu/ppc/ppc_context.h"
 #include "xenia/hid/input.h"
 #include "xenia/hid/input_driver.h"
 #include "xenia/xbox.h"
@@ -20,6 +21,13 @@
 #include "xenia/ui/imgui_host_notification.h"
 #endif
 namespace xe {
+namespace cpu {
+namespace ppc {
+using MouseHookMidHook = void (*)(PPCContext* context, void* arg0, void* arg1);
+extern void RegisterMidHookASM(uint32_t address,
+                               MouseHookMidHook hook_function);
+};  // namespace ppc
+};  // namespace cpu
 namespace hid {
 namespace winkey {
 static bool mousehook_message_read;
@@ -34,7 +42,10 @@ struct RawInputState {
   MouseEvent mouse;
   bool* key_states;
 };
-
+enum MidHookStatus : BYTE {
+  NOT_HOOKED,
+  HOOKED,
+};
 class HookableGame {
  public:
   virtual ~HookableGame() = default;
@@ -50,6 +61,8 @@ class HookableGame {
                                    RawInputState& input_state,
                                    X_INPUT_STATE* out_state, int weapon,
                                    uint16_t buttons) = 0;
+  MidHookStatus midhook_status = NOT_HOOKED;
+  virtual void MidHookInit() = 0;
 };
 
 xe::be<uint32_t>* multi_pointer(uint32_t base_address,

--- a/src/xenia/hid/winkey/hookables/hookable_game.h
+++ b/src/xenia/hid/winkey/hookables/hookable_game.h
@@ -46,6 +46,7 @@ enum MidHookStatus : BYTE {
   NOT_HOOKED,
   HOOKED,
 };
+static RawInputState static_state;
 class HookableGame {
  public:
   virtual ~HookableGame() = default;

--- a/src/xenia/hid/winkey/hookables/hookable_game.h
+++ b/src/xenia/hid/winkey/hookables/hookable_game.h
@@ -46,7 +46,6 @@ enum MidHookStatus : BYTE {
   NOT_HOOKED,
   HOOKED,
 };
-static RawInputState static_state;
 class HookableGame {
  public:
   virtual ~HookableGame() = default;

--- a/src/xenia/hid/winkey/winkey_input_driver.cc
+++ b/src/xenia/hid/winkey/winkey_input_driver.cc
@@ -728,6 +728,9 @@ X_RESULT WinKeyInputDriver::GetState(uint32_t user_index,
           game->WeaponSwitchHandler(user_index, state, out_state, weapon,
                                     buttons);
         }
+        if (game->midhook_status == MidHookStatus::NOT_HOOKED) {
+          game->MidHookInit();
+        }
         break;
       }
     }

--- a/src/xenia/hid/winkey/winkey_input_driver.cc
+++ b/src/xenia/hid/winkey/winkey_input_driver.cc
@@ -40,6 +40,12 @@ DEFINE_bool(swap_wheel, false,
             "will go to prev, also changes the weapon wheel & map zoom "
             "direction in Saints Row 1.",
             "MouseHook");
+
+DEFINE_bool(internal_hook, true,
+            "Uses better hooking technique that produces better mouse "
+            "injection results (currently only for Saints Row 1)",
+            "MouseHook");
+
 DEFINE_double(sensitivity, 1, "Mouse sensitivity", "MouseHook");
 DEFINE_double(
     fov_sensitivity, 0.9,


### PR DESCRIPTION
Thanks to @Gliniak for basically showing me how to do this

Basically implements a way and an interface in hookable_games to be able to hook ANYWHERE within a game, and gives us a PPC context during that address, this should make doing mousehook for a lot of games certainly a lot easier, 

This is kind of similar to what [XenonRecomp](https://github.com/hedge-dev/XenonRecomp) does with their MidHooks I believe

I'm not sure if this effects performance or not.

MidHookInit is a virtual function in the HookableGame class, and has to be executed only ONCE, otherwise repeats will occur, right now there isn't any unloading as Xenia doesn't really support that either.

I'm not sure if PPC has a register for current instruction counter, so not sure if we can skip over chunk of code.

This also implements a midhook for Saints Row 1 which makes x-axis perform way better, pretty much fixing the possibles stutters that occur when the game drops FPS.

