### PR TITLE
Midhook refactor

### DIFF
--- a/src/xenia/cpu/ppc/ppc_frontend.cc
+++ b/src/xenia/cpu/ppc/ppc_frontend.cc
@@ -54,24 +54,15 @@ PPCFrontend::~PPCFrontend() {
 
 Memory* PPCFrontend::memory() const { return processor_->memory(); }
 
-using MouseHookMidHook = void (*)(PPCContext* context, void* arg0, void* arg1);
-std::unordered_map<uint32_t, std::vector<MouseHookMidHook>> g_AddressHooks;
+std::unordered_map<uint32_t, MouseHookMidHook> g_AddressHooks;
 
 void RegisterMidHookASM(uint32_t address, MouseHookMidHook hook_function) {
   XELOGW("RegisterMidHookASM: Hooking address {:08X}", address);
-  g_AddressHooks[address].push_back(hook_function);
+  g_AddressHooks[address] = hook_function;
 }
-// arg0 holds the guest address this builtin was created for, baked in at
-// DefineBuiltin time. No scratch access needed.
-void MidHookHandler(PPCContext* ppc_context, void* arg0, void* arg1) {
-  uint32_t hook_address =
-      static_cast<uint32_t>(reinterpret_cast<uintptr_t>(arg0));
 
-  if (auto it = g_AddressHooks.find(hook_address); it != g_AddressHooks.end()) {
-    for (const auto& hook_func : it->second) {
-      hook_func(ppc_context, arg0, arg1);
-    }
-  }
+bool HasMidHookAt(uint32_t address) {
+  return g_AddressHooks.count(address) > 0;
 }
 
 // Checks the state of the global lock and sets scratch to the current MSR
@@ -116,9 +107,9 @@ Function* PPCFrontend::GetOrCreateMidHookBuiltin(uint32_t address) {
   if (it != midhook_builtins_.end()) {
     return it->second;
   }
-  auto* fn = processor_->DefineBuiltin(
-      fmt::format("MidHook_{:08X}", address), MidHookHandler,
-      reinterpret_cast<void*>(static_cast<uintptr_t>(address)), nullptr);
+  auto* fn =
+      processor_->DefineBuiltin(fmt::format("MidHook_{:08X}", address),
+                                g_AddressHooks.at(address), nullptr, nullptr);
   midhook_builtins_[address] = fn;
   return fn;
 }

--- a/src/xenia/cpu/ppc/ppc_frontend.cc
+++ b/src/xenia/cpu/ppc/ppc_frontend.cc
@@ -9,6 +9,7 @@
 
 #include "xenia/cpu/ppc/ppc_frontend.h"
 
+#include "third_party/fmt/include/fmt/format.h"
 #include "xenia/base/atomic.h"
 #include "xenia/base/logging.h"
 #include "xenia/base/mutex.h"
@@ -60,8 +61,11 @@ void RegisterMidHookASM(uint32_t address, MouseHookMidHook hook_function) {
   XELOGW("RegisterMidHookASM: Hooking address {:08X}", address);
   g_AddressHooks[address].push_back(hook_function);
 }
-void MyHook(PPCContext* ppc_context, void* arg0, void* arg1) {
-  uint32_t hook_address = static_cast<uint32_t>(ppc_context->scratch);
+// arg0 holds the guest address this builtin was created for, baked in at
+// DefineBuiltin time. No scratch access needed.
+void MidHookHandler(PPCContext* ppc_context, void* arg0, void* arg1) {
+  uint32_t hook_address =
+      static_cast<uint32_t>(reinterpret_cast<uintptr_t>(arg0));
 
   if (auto it = g_AddressHooks.find(hook_address); it != g_AddressHooks.end()) {
     for (const auto& hook_func : it->second) {
@@ -107,10 +111,21 @@ void SyscallHandler(PPCContext* ppc_context, void* arg0, void* arg1) {
   }
 }
 
+Function* PPCFrontend::GetOrCreateMidHookBuiltin(uint32_t address) {
+  auto it = midhook_builtins_.find(address);
+  if (it != midhook_builtins_.end()) {
+    return it->second;
+  }
+  auto* fn = processor_->DefineBuiltin(
+      fmt::format("MidHook_{:08X}", address), MidHookHandler,
+      reinterpret_cast<void*>(static_cast<uintptr_t>(address)), nullptr);
+  midhook_builtins_[address] = fn;
+  return fn;
+}
+
 bool PPCFrontend::Initialize() {
   void* arg0 = reinterpret_cast<void*>(&xe::global_critical_region::mutex());
   void* arg1 = reinterpret_cast<void*>(&builtins_.global_lock_count);
-  builtins_.my_hook = processor_->DefineBuiltin("MyHook", MyHook, arg0, arg1);
   builtins_.check_global_lock =
       processor_->DefineBuiltin("CheckGlobalLock", CheckGlobalLock, arg0, arg1);
   builtins_.enter_global_lock =

--- a/src/xenia/cpu/ppc/ppc_frontend.h
+++ b/src/xenia/cpu/ppc/ppc_frontend.h
@@ -65,6 +65,10 @@ class PPCFrontend {
 // Checks the state of the global lock and sets scratch to the current MSR
 // value.
 void CheckGlobalLock(PPCContext* ppc_context, void* arg0, void* arg1);
+
+using MouseHookMidHook = void (*)(PPCContext* context, void* arg0, void* arg1);
+void RegisterMidHookASM(uint32_t address, MouseHookMidHook hook_function);
+bool HasMidHookAt(uint32_t address);
 }  // namespace ppc
 }  // namespace cpu
 }  // namespace xe

--- a/src/xenia/cpu/ppc/ppc_frontend.h
+++ b/src/xenia/cpu/ppc/ppc_frontend.h
@@ -11,6 +11,7 @@
 #define XENIA_CPU_PPC_PPC_FRONTEND_H_
 
 #include <memory>
+#include <unordered_map>
 
 #include "xenia/base/type_pool.h"
 #include "xenia/cpu/function.h"
@@ -34,7 +35,6 @@ struct PPCBuiltins {
   Function* enter_global_lock;
   Function* leave_global_lock;
   Function* syscall_handler;
-  Function* my_hook;
 };
 
 class PPCFrontend {
@@ -51,10 +51,16 @@ class PPCFrontend {
   bool DeclareFunction(GuestFunction* function);
   bool DefineFunction(GuestFunction* function, uint32_t debug_info_flags);
 
+  // Returns (creating if needed) a per-address builtin for the mid-hook at
+  // the given guest address. The address is baked into arg0 so the handler
+  // never needs to touch scratch.
+  Function* GetOrCreateMidHookBuiltin(uint32_t address);
+
  private:
   Processor* processor_;
   PPCBuiltins builtins_ = {0};
   TypePool<PPCTranslator, PPCFrontend*> translator_pool_;
+  std::unordered_map<uint32_t, Function*> midhook_builtins_;
 };
 // Checks the state of the global lock and sets scratch to the current MSR
 // value.

--- a/src/xenia/cpu/ppc/ppc_hir_builder.cc
+++ b/src/xenia/cpu/ppc/ppc_hir_builder.cc
@@ -173,12 +173,8 @@ bool PPCHIRBuilder::Emit(GuestFunction* function, uint32_t flags) {
       ContextBarrier();
     }
 
-    if (g_AddressHooks.find(address) != g_AddressHooks.end()) {
-      // Store the current address in scratch before calling the hook
-      auto store_addr = LoadConstantUint32(address);
-      StoreContext(offsetof(PPCContext, scratch),
-                   ZeroExtend(store_addr, INT64_TYPE));
-      CallExtern(builtins()->my_hook);
+    if (g_AddressHooks.count(address)) {
+      CallExtern(frontend_->GetOrCreateMidHookBuiltin(address));
     }
     MaybeBreakOnInstruction(address);
 

--- a/src/xenia/cpu/ppc/ppc_hir_builder.cc
+++ b/src/xenia/cpu/ppc/ppc_hir_builder.cc
@@ -38,8 +38,7 @@ namespace xe {
 namespace cpu {
 namespace ppc {
 using MouseHookMidHook = void (*)(PPCContext* context, void* arg0, void* arg1);
-extern std::unordered_map<uint32_t, std::vector<MouseHookMidHook>>
-    g_AddressHooks;
+extern std::unordered_map<uint32_t, MouseHookMidHook> g_AddressHooks;
 
 // TODO(benvanik): remove when enums redefined.
 using namespace xe::cpu::hir;


### PR DESCRIPTION
Better Midhooks, before I relied on scratch which could be a lock now it's way cleaner and the actual function handler workaround from before is gone so there's no lookup table anymore and just directly hooks it with the direct function